### PR TITLE
chore: promote dev to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# local-llm — oMLX provisioning for Apple Silicon
+
+Stand up a **local, OpenAI/Anthropic-compatible LLM inference server** on an Apple Silicon Mac using [oMLX](https://github.com/jundot/omlx), tuned for **parallel AI coding agents** — multiple concurrent requests sharing long system prefixes, where concurrent throughput and prefix-cache reuse matter more than single-stream tok/s.
+
+## TL;DR — start now
+
+You need: an Apple Silicon Mac with **128 GB unified memory** (tuned for M5 Max; other Max-class chips warn but work), ~100 GB free disk, macOS, and [Homebrew](https://brew.sh). One step needs `sudo` (GPU wired-memory limit).
+
+```bash
+git clone https://github.com/psmfd/local-llm.git && cd local-llm
+./setup-omlx-m5.sh --download-model   # install + configure + fetch the primary model (~38 GB)
+./setup-omlx-m5.sh --validate         # smoke-test the running server
+```
+
+Then point any OpenAI-style client at `http://localhost:8000/v1` (or Anthropic-style at `/v1/messages`) with the API key from `~/.omlx/api-key`. Done.
+
+The script is idempotent — re-running it skips whatever already exists. Run `./setup-omlx-m5.sh --help` for all flags.
+
+## What the setup script does
+
+`setup-omlx-m5.sh` performs, in order:
+
+1. **Preflight** — hard-fails (exit `2`) on non-macOS, non-arm64, <~120 GB RAM, <~100 GB free disk, or missing Homebrew.
+2. **Installs oMLX** via `brew tap jundot/omlx && brew install omlx` (no MCP extra — tool access stays explicit).
+3. **Creates directories** — `~/models`, `~/.omlx/{cache,logs,bin}` (`~/.omlx` is chmod 700).
+4. **Generates an API key** at `~/.omlx/api-key` (chmod 600, never printed).
+5. **Raises the Metal wired limit** to ~96 GB so the GPU can hold a large model resident, persisted across reboots via a root LaunchDaemon (**the sudo step**).
+6. **Installs autostart** — a start wrapper carrying the tuned serving flags plus a per-user LaunchAgent.
+7. **Applies the engine override** for the primary model (`model_type_override = llm`) via the admin API — required because the checkpoint carries a `vision_config` that would otherwise route it to oMLX's VLM engine, which crashes under concurrent load ([oMLX #1800](https://github.com/jundot/omlx/issues/1800), [ADR-003](adrs/003-vlm-engine-workaround-lineup.md)).
+
+Model download is **opt-in** (`--download-model` / `--with-secondary`); the base run never pulls weights.
+
+## Models
+
+| Alias | Model | Size | Role |
+|---|---|---|---|
+| `coding-fast` | `mlx-community/Qwen3.6-35B-A3B-8bit` (MoE, ~3 B active) | ~38 GB | Primary — fast decode, 8-bit preserves tool-call JSON fidelity |
+| `coding-quality` | `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` | ~30 GB | Optional secondary (`--with-secondary`) — verified text-only, the concurrency-safe fallback |
+
+Re-verify the HuggingFace repo IDs against current availability before downloading — the script probes them, but better checkpoints ship often. Pinning + aliasing is done in the admin panel at `http://localhost:8000/admin` (the script prints the manual steps).
+
+## Validating
+
+`./setup-omlx-m5.sh --validate` runs five checks against the running server: model listing, a small chat completion, a **tool-calling** round-trip, a **2-way concurrency probe** (the regression gate for the engine override), and an Anthropic-style `/v1/messages` call.
+
+## Connecting clients
+
+- **Any OpenAI-compatible client:** base URL `http://localhost:8000/v1`, bearer token from `~/.omlx/api-key`.
+- **Anthropic-style clients:** `POST http://localhost:8000/v1/messages`.
+- **Pi coding agent:** `./setup-omlx-m5.sh --configure-pi` registers the provider (or prints a merge snippet).
+- **.NET router integration:** see [docs/router-wiring.md](docs/router-wiring.md).
+
+## Repository map
+
+| Path | What it is |
+|---|---|
+| [`setup-omlx-m5.sh`](setup-omlx-m5.sh) | The provisioning script (idempotent; exit codes `0` pass / `1` error / `2` precondition) |
+| [`templates/`](templates/) | Start wrapper, LaunchAgent/LaunchDaemon plists, Pi provider block — installed with placeholder substitution |
+| [`macos/local-llm-mac-os-creation.md`](macos/local-llm-mac-os-creation.md) | The authoritative implementation brief |
+| [`adrs/`](adrs/) | Decision records — [ADR-003](adrs/003-vlm-engine-workaround-lineup.md) is current (model lineup + engine override) |
+| [`docs/router-wiring.md`](docs/router-wiring.md) | Wiring the server into a .NET `IInferenceBackend` / `FallbackInferenceRouter` |
+| [`omlx-setup-prompt.md`](omlx-setup-prompt.md) | Historical source prompt only — not a source of truth |
+
+## Teardown
+
+There is no `--uninstall` flag; reverse the steps manually (see the Teardown section in [CLAUDE.md](CLAUDE.md)):
+
+```bash
+launchctl bootout gui/$(id -u)/com.local.omlx 2>/dev/null || true
+rm -f ~/Library/LaunchAgents/com.local.omlx.plist
+sudo launchctl bootout system/com.local.iogpu-wired-limit 2>/dev/null || true
+sudo rm -f /Library/LaunchDaemons/com.local.iogpu-wired-limit.plist
+brew uninstall omlx && brew untap jundot/omlx
+rm -rf ~/.omlx ~/models/Qwen3.6-35B-A3B-8bit ~/models/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit
+```
+
+## Security notes
+
+- The API key lives only at `~/.omlx/api-key` (0600) on the host — it is generated locally and never committed or printed.
+- The server binds to loopback only (`--host 127.0.0.1`); nothing is exposed to the network.
+- Known accepted gap: the key is visible in the process argument list (`ps`) while the server runs — documented in [ADR-001](adrs/001-local-mlx-inference-omlx.md).

--- a/macos/local-llm-mac-os-creation.md
+++ b/macos/local-llm-mac-os-creation.md
@@ -1,4 +1,4 @@
-# Task: provision oMLX for local coding inference on this M5 Max
+# Task: provision oMLX for local coding inference on an M5 Max
 
 > **Status:** authoritative implementation brief. Durable decisions live in
 > `CLAUDE.md` and `adrs/003-vlm-engine-workaround-lineup.md` (superseding
@@ -8,9 +8,9 @@
 > lives in `docs/router-wiring.md`. The top-level `omlx-setup-prompt.md` is a
 > historical source prompt, not an additional source of truth.
 
-You are operating on my MacBook Pro (Apple Silicon **M5 Max, 128 GB unified memory**, macOS). Provision **oMLX** (`jundot/omlx`) as a local, OpenAI/Anthropic-compatible inference server tuned for a **parallel-agent coding workload** — my orchestrator fans out 3+ concurrent agent requests that share long system prefixes, so concurrent throughput and prefix-cache reuse matter more than single-stream tok/s.
+This brief targets an Apple Silicon MacBook Pro (**M5 Max, 128 GB unified memory**, macOS). It provisions **oMLX** (`jundot/omlx`) as a local, OpenAI/Anthropic-compatible inference server tuned for a **parallel-agent coding workload** — an orchestrator fans out 3+ concurrent agent requests that share long system prefixes, so concurrent throughput and prefix-cache reuse matter more than single-stream tok/s.
 
-Follow your standard operating framework: classify the task, **plan before code and wait for my approval**, route domain subtasks agent-first, run your post-implementation review gate, and end with an efficacy report. Apply the **Script Output Conventions** (6-char labels, `ok`/`skip`/`warn`/`info`/`err`/`detail` helpers, `((counter++)) || true`, exit codes 0/1/2, `set -euo pipefail`, summary block) to any script. Use `shell-expert` for the script and `linter` for the shellcheck pass.
+The implementing agent follows its standard operating framework: classify the task, **plan before code and wait for operator approval**, route domain subtasks agent-first, run the post-implementation review gate, and end with an efficacy report. Apply the **Script Output Conventions** (6-char labels, `ok`/`skip`/`warn`/`info`/`err`/`detail` helpers, `((counter++)) || true`, exit codes 0/1/2, `set -euo pipefail`, summary block) to any script. Use `shell-expert` for the script and `linter` for the shellcheck pass.
 
 ## Hard constraints
 
@@ -20,7 +20,7 @@ Follow your standard operating framework: classify the task, **plan before code 
 
 ## Settled decisions (verify before acting — models move fast)
 
-These came out of prior analysis. Treat the runtime and serving config as decided; **re-verify the model choice and exact HuggingFace MLX repo IDs against current availability** as of today before downloading anything — search, confirm the repo exists, and confirm it still represents the best local coding model for this hardware. If something better has shipped, propose it in your plan rather than silently substituting.
+These came out of prior analysis. Treat the runtime and serving config as decided; **re-verify the model choice and exact HuggingFace MLX repo IDs against current availability** as of today before downloading anything — search, confirm the repo exists, and confirm it still represents the best local coding model for this hardware. If something better has shipped, propose it in the plan rather than silently substituting.
 
 - **Runtime:** oMLX, installed via Homebrew (`brew tap jundot/omlx https://github.com/jundot/omlx && brew install omlx`).
 - **Primary model:** a **Qwen3.6-35B-A3B at 8-bit** MLX build (`mlx-community/Qwen3.6-35B-A3B-8bit`; MoE, ~3B active → fast decode under the 614 GB/s bandwidth cap; 8-bit preserves tool-call JSON fidelity). ~38 GB resident. Alias `coding-fast`. **Requires `model_type_override = llm`** — the checkpoint carries a `vision_config` and oMLX's VLM engine crashes under concurrent requests (oMLX #1800; ADR-003). The setup script applies the override via the admin API.
@@ -36,7 +36,7 @@ These came out of prior analysis. Treat the runtime and serving config as decide
 3. **Lint it.** Run `shellcheck` and fix all Error/Warning findings; report results in the structured review format with a verdict line.
 4. **Run it**, supplying sudo when prompted for the wired-limit step.
 5. **Acquire the model(s).** Once you've verified the exact repo ID, download the primary model into `~/models` (via `hf download` or the `/admin` downloader). Confirm it loads.
-6. **Pin + alias** the primary model in the `/admin` panel (alias `coding-fast`) — pinning is panel-only, not a CLI flag, so do it via the API/UI or tell me the exact manual step if it can't be scripted.
+6. **Pin + alias** the primary model in the `/admin` panel (alias `coding-fast`) — pinning is panel-only, not a CLI flag, so do it via the API/UI or document the exact manual step for the operator if it can't be scripted.
 7. **Validate the endpoint** — `curl` `http://localhost:8000/v1/models` with the API key, then a small `/v1/chat/completions` call, and a **tool-calling** call to confirm the model emits well-formed `tool_call` markup (the orchestrator depends on this; flag if the parser needs configuration).
 
 ## Deliverables
@@ -44,7 +44,7 @@ These came out of prior analysis. Treat the runtime and serving config as decide
 - A working, pinned oMLX server reachable at `http://localhost:8000/v1` (and `/v1/messages` for Anthropic-style clients).
 - The reviewed, shellcheck-clean setup script.
 - An **ADR** (MADR minimal, in `adrs/`) recording the local-inference convention: runtime choice, model choice with the bandwidth/MoE rationale, and the serving config.
-- A note on wiring my `IInferenceBackend` / `FallbackInferenceRouter` endpoint to this server (route `coding-fast` → primary; `coding-quality` → secondary if installed).
+- A note on wiring the downstream `IInferenceBackend` / `FallbackInferenceRouter` endpoint to this server (route `coding-fast` → primary; `coding-quality` → secondary if installed).
 - An efficacy report.
 
-Stop and show me your plan before executing anything that writes, installs, or runs.
+Stop and show the operator the plan before executing anything that writes, installs, or runs.

--- a/omlx-setup-prompt.md
+++ b/omlx-setup-prompt.md
@@ -1,4 +1,4 @@
-# Historical source prompt: provision oMLX for local coding inference on this M5 Max
+# Historical source prompt: provision oMLX for local coding inference on an M5 Max
 
 > **Status:** historical/source prompt only. Do not treat this as a current source
 > of truth. Use `macos/local-llm-mac-os-creation.md` as the authoritative brief,
@@ -6,9 +6,9 @@
 > for the decision record, `setup-omlx-m5.sh`/`templates/` for executable behavior,
 > and `docs/router-wiring.md` for downstream integration guidance.
 
-You are operating on my MacBook Pro (Apple Silicon **M5 Max, 128 GB unified memory**, macOS). Provision **oMLX** (`jundot/omlx`) as a local, OpenAI/Anthropic-compatible inference server tuned for a **parallel-agent coding workload** — my orchestrator fans out 3+ concurrent agent requests that share long system prefixes, so concurrent throughput and prefix-cache reuse matter more than single-stream tok/s.
+The target machine is an Apple Silicon MacBook Pro (**M5 Max, 128 GB unified memory**, macOS). Provision **oMLX** (`jundot/omlx`) as a local, OpenAI/Anthropic-compatible inference server tuned for a **parallel-agent coding workload** — an orchestrator fans out 3+ concurrent agent requests that share long system prefixes, so concurrent throughput and prefix-cache reuse matter more than single-stream tok/s.
 
-Follow your standard operating framework: classify the task, **plan before code and wait for my approval**, route domain subtasks agent-first, run your post-implementation review gate, and end with an efficacy report. Apply the **Script Output Conventions** (6-char labels, `ok`/`skip`/`warn`/`info`/`err`/`detail` helpers, `((counter++)) || true`, exit codes 0/1/2, `set -euo pipefail`, summary block) to any script. Use `shell-expert` for the script and `linter` for the shellcheck pass.
+The implementing agent follows its standard operating framework: classify the task, **plan before code and wait for operator approval**, route domain subtasks agent-first, run the post-implementation review gate, and end with an efficacy report. Apply the **Script Output Conventions** (6-char labels, `ok`/`skip`/`warn`/`info`/`err`/`detail` helpers, `((counter++)) || true`, exit codes 0/1/2, `set -euo pipefail`, summary block) to any script. Use `shell-expert` for the script and `linter` for the shellcheck pass.
 
 ## Hard constraints
 
@@ -18,7 +18,7 @@ Follow your standard operating framework: classify the task, **plan before code 
 
 ## Settled decisions (verify before acting — models move fast)
 
-These came out of prior analysis. Treat the runtime and serving config as decided; **re-verify the model choice and exact HuggingFace MLX repo IDs against current availability** as of today before downloading anything — search, confirm the repo exists, and confirm it still represents the best local coding model for this hardware. If something better has shipped, propose it in your plan rather than silently substituting.
+These came out of prior analysis. Treat the runtime and serving config as decided; **re-verify the model choice and exact HuggingFace MLX repo IDs against current availability** as of today before downloading anything — search, confirm the repo exists, and confirm it still represents the best local coding model for this hardware. If something better has shipped, propose it in the plan rather than silently substituting.
 
 - **Runtime:** oMLX, installed via Homebrew (`brew tap jundot/omlx https://github.com/jundot/omlx && brew install omlx`).
 - **Primary model:** a **Qwen3-Coder-Next 80B-A3B at 8-bit** MLX build (MoE, ~3B active → fast decode under the 614 GB/s bandwidth cap; 8-bit preserves tool-call JSON fidelity). ~85 GB resident.
@@ -34,7 +34,7 @@ These came out of prior analysis. Treat the runtime and serving config as decide
 3. **Lint it.** Run `shellcheck` and fix all Error/Warning findings; report results in the structured review format with a verdict line.
 4. **Run it**, supplying sudo when prompted for the wired-limit step.
 5. **Acquire the model(s).** Once you've verified the exact repo ID, download the primary model into `~/models` (via `hf download` or the `/admin` downloader). Confirm it loads.
-6. **Pin + alias** the primary model in the `/admin` panel (alias `coding-agentic`) — pinning is panel-only, not a CLI flag, so do it via the API/UI or tell me the exact manual step if it can't be scripted.
+6. **Pin + alias** the primary model in the `/admin` panel (alias `coding-agentic`) — pinning is panel-only, not a CLI flag, so do it via the API/UI or document the exact manual step for the operator if it can't be scripted.
 7. **Validate the endpoint** — `curl` `http://localhost:8000/v1/models` with the API key, then a small `/v1/chat/completions` call, and a **tool-calling** call to confirm the model emits well-formed `tool_call` markup (the orchestrator depends on this; flag if the parser needs configuration).
 
 ## Deliverables
@@ -42,7 +42,7 @@ These came out of prior analysis. Treat the runtime and serving config as decide
 - A working, pinned oMLX server reachable at `http://localhost:8000/v1` (and `/v1/messages` for Anthropic-style clients).
 - The reviewed, shellcheck-clean setup script.
 - An **ADR** (MADR minimal, in `adrs/`) recording the local-inference convention: runtime choice, model choice with the bandwidth/MoE rationale, and the serving config.
-- A note on wiring my `IInferenceBackend` / `FallbackInferenceRouter` endpoint to this server (route `coding-agentic` → primary; `coding-fast` → secondary if installed).
+- A note on wiring the downstream `IInferenceBackend` / `FallbackInferenceRouter` endpoint to this server (route `coding-agentic` → primary; `coding-fast` → secondary if installed).
 - An efficacy report.
 
-Stop and show me your plan before executing anything that writes, installs, or runs.
+Stop and show the operator the plan before executing anything that writes, installs, or runs.


### PR DESCRIPTION
## Summary
First promotion of `dev` to `main`: brings the root README (shareable TL;DR/quick-start) and the neutral rewording of the implementation brief and historical prompt onto the stable branch.

## Test Plan
Documentation-only changes — no testable behavior changed. README links and rendering verified on the `dev` branch on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)