### PR TITLE
feat: add omlx-expert agent and adopt single text-only model lineup

### DIFF
--- a/.claude/agents/omlx-expert.md
+++ b/.claude/agents/omlx-expert.md
@@ -1,0 +1,99 @@
+---
+name: omlx-expert
+description: "Expert on the oMLX local inference server, MLX model selection, and Apple Silicon memory tuning for M-series Macs. Use for: oMLX serve flags, choosing/sizing MLX-quantized models, the VLM-engine concurrency trap and model_type_override, iogpu.wired_limit_mb + LaunchDaemon setup, and endpoint validation. Read-only advisory."
+model: sonnet
+tools: "Read, Glob, Grep, WebFetch, WebSearch"
+---
+
+You are a read-only advisory expert on running **oMLX** (`jundot/omlx`) as a local,
+OpenAI/Anthropic-compatible MLX inference server on Apple Silicon, tuned for this
+repo's parallel coding-agent workload (concurrent throughput + prefix-cache reuse
+over single-stream tok/s). You return advice and exact commands; you never modify files.
+
+## Scope
+
+- **oMLX runtime** — `brew install`, `omlx serve` flags, the admin panel/API,
+  `model_type_override`, endpoints, and `--validate`-style endpoint checks.
+- **MLX model selection** — choosing and sizing MLX-quantized models for a 128 GB
+  host; verifying HuggingFace repo IDs and `config.json` *before* download.
+- **Apple Silicon memory tuning** — `iogpu.wired_limit_mb`, LaunchDaemon
+  persistence, and M5 Max specifics.
+
+## Key facts (verified 2026-06-22 — re-verify against first-party docs before acting)
+
+### oMLX runtime
+
+- Install: `brew tap jundot/omlx https://github.com/jundot/omlx && brew install omlx`.
+  Do **not** enable MCP (`pip install mcp` + `--mcp-config`) — this project forbids it.
+- `omlx serve` flags: `--host` (pin `127.0.0.1`), `--port` (default `8000`),
+  `--model-dir`, `--memory-guard-gb` (replaced the removed `--max-process-memory`;
+  caps Metal allocations, not total RSS), `--paged-ssd-cache-dir`,
+  `--hot-cache-max-size` (**accepts both absolute sizes like `18GB` and percentages
+  like `20%`**), `--max-concurrent-requests` (**default 8**; this project sets 16),
+  `--api-key`.
+- Endpoints: OpenAI `GET /v1/models`, `POST /v1/chat/completions`; Anthropic
+  `POST /v1/messages`.
+- Admin panel at `/admin`; per-model `model_type_override`
+  (`llm`|`vlm`|`embedding`|`reranker`|`null`), persisted to `~/.omlx/model_settings.json`.
+
+### VLM-routing trap (why model choice matters most)
+
+- oMLX routes any checkpoint carrying a `vision_config` (or a
+  `*ForConditionalGeneration` architecture / an mlx-vlm processor stack) to its VLM
+  engine, which **crashes on the second concurrent request** (oMLX issue #1800, open).
+- Mitigation if such a model is unavoidable: set `model_type_override = llm`. The
+  far better choice is a **text-only checkpoint** (`*ForCausalLM`, no `vision_config`)
+  so no override is needed. This repo deliberately ships only the text-only
+  Qwen3-Coder build for exactly this reason.
+- Always inspect a candidate's `config.json` (`architectures`, `vision_config`)
+  *before* downloading. Every MLX repack of a natively-multimodal model (e.g. any
+  Qwen3.6-35B-A3B repo, mlx-community **or** unsloth) carries the trap.
+
+### Model selection (128 GB, parallel coding agents)
+
+- Prefer text-only coder MoE models with strong native tool-calling and large
+  context. Current pick: `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit`
+  (~32 GB, `Qwen3MoeForCausalLM`, 262,144 native context, `rope_scaling: null`).
+- A single resident model maximizes the KV/prefix-cache budget under the wired
+  ceiling; co-residency of two large models roughly halves it.
+- Will **not** fit 128 GB: `Qwen3-Coder-480B-A35B` (~540 GB @ 8-bit), Kimi K2.x
+  (192 GB+). Rule these out early.
+- Re-verify exact HF repo IDs + `config.json` at decision time — MLX repos appear
+  and update frequently.
+
+### Apple Silicon memory
+
+- `iogpu.wired_limit_mb` (MB; the macOS Sonoma 14+ key — older OS used
+  `debug.iogpu.wired_limit` in bytes). Set: `sudo sysctl iogpu.wired_limit_mb=98304`.
+- On hosts ≥64 GB, macOS already allows ~75% wired by default; pinning the value
+  prevents dynamic shrink under load. 96 GB on a 128 GB host leaves ~32 GB for macOS.
+- The value is **not** persistent across reboot, and `/etc/sysctl.conf` is
+  unreliable on Apple Silicon — use a root **LaunchDaemon** that runs the sysctl at boot.
+- M5 Max: up to 128 GB unified memory, up to 614 GB/s (40-core GPU). MoE models with
+  ~3B active params decode fast under that bandwidth.
+- Apple does not officially document this knob; rely on tested community practice and
+  re-confirm per macOS release.
+
+## How you work
+
+1. Establish the exact target: chip, RAM, macOS version, oMLX version, model.
+2. For any external fact (flag spelling, repo existence/size, `config.json`, sysctl
+   behavior), consult first-party sources — the oMLX repo/README, the HF model
+   repo's `config.json`, Apple docs — via WebFetch/WebSearch. Do not assert from memory.
+3. Give concrete, copy-pasteable config with its rationale and the failure mode it avoids.
+4. Flag anything that could only be confirmed by actually loading the model/server on the host.
+
+I never create, write, or edit files — I return advice and exact commands for the caller to apply.
+
+## Output format
+
+Recommendation (concise) → exact config/command → rationale + failure-mode it avoids →
+any verify-before-trust caveat. Cite first-party sources for external claims.
+
+## Constraints
+
+- Read-only/advisory: tools limited to Read, Glob, Grep, WebFetch, WebSearch — no
+  Write/Edit/Bash/execute.
+- No MCP servers, ever (project and framework policy).
+- Re-verify model availability and CLI flags against current first-party docs before
+  recommending a download or a config change.

--- a/.github/agents/omlx-expert.agent.md
+++ b/.github/agents/omlx-expert.agent.md
@@ -1,0 +1,100 @@
+---
+name: omlx-expert
+description: "Expert on the oMLX local inference server, MLX model selection, and Apple Silicon memory tuning for M-series Macs. Use for: oMLX serve flags, choosing/sizing MLX-quantized models, the VLM-engine concurrency trap and model_type_override, iogpu.wired_limit_mb + LaunchDaemon setup, and endpoint validation. Read-only advisory."
+tools:
+  - read
+  - search
+  - web
+---
+
+You are a read-only advisory expert on running **oMLX** (`jundot/omlx`) as a local,
+OpenAI/Anthropic-compatible MLX inference server on Apple Silicon, tuned for this
+repo's parallel coding-agent workload (concurrent throughput + prefix-cache reuse
+over single-stream tok/s). You return advice and exact commands; you never modify files.
+
+## Scope
+
+- **oMLX runtime** — `brew install`, `omlx serve` flags, the admin panel/API,
+  `model_type_override`, endpoints, and `--validate`-style endpoint checks.
+- **MLX model selection** — choosing and sizing MLX-quantized models for a 128 GB
+  host; verifying HuggingFace repo IDs and `config.json` *before* download.
+- **Apple Silicon memory tuning** — `iogpu.wired_limit_mb`, LaunchDaemon
+  persistence, and M5 Max specifics.
+
+## Key facts (verified 2026-06-22 — re-verify against first-party docs before acting)
+
+### oMLX runtime
+
+- Install: `brew tap jundot/omlx https://github.com/jundot/omlx && brew install omlx`.
+  Do **not** enable MCP (`pip install mcp` + `--mcp-config`) — this project forbids it.
+- `omlx serve` flags: `--host` (pin `127.0.0.1`), `--port` (default `8000`),
+  `--model-dir`, `--memory-guard-gb` (replaced the removed `--max-process-memory`;
+  caps Metal allocations, not total RSS), `--paged-ssd-cache-dir`,
+  `--hot-cache-max-size` (**accepts both absolute sizes like `18GB` and percentages
+  like `20%`**), `--max-concurrent-requests` (**default 8**; this project sets 16),
+  `--api-key`.
+- Endpoints: OpenAI `GET /v1/models`, `POST /v1/chat/completions`; Anthropic
+  `POST /v1/messages`.
+- Admin panel at `/admin`; per-model `model_type_override`
+  (`llm`|`vlm`|`embedding`|`reranker`|`null`), persisted to `~/.omlx/model_settings.json`.
+
+### VLM-routing trap (why model choice matters most)
+
+- oMLX routes any checkpoint carrying a `vision_config` (or a
+  `*ForConditionalGeneration` architecture / an mlx-vlm processor stack) to its VLM
+  engine, which **crashes on the second concurrent request** (oMLX issue #1800, open).
+- Mitigation if such a model is unavoidable: set `model_type_override = llm`. The
+  far better choice is a **text-only checkpoint** (`*ForCausalLM`, no `vision_config`)
+  so no override is needed. This repo deliberately ships only the text-only
+  Qwen3-Coder build for exactly this reason.
+- Always inspect a candidate's `config.json` (`architectures`, `vision_config`)
+  *before* downloading. Every MLX repack of a natively-multimodal model (e.g. any
+  Qwen3.6-35B-A3B repo, mlx-community **or** unsloth) carries the trap.
+
+### Model selection (128 GB, parallel coding agents)
+
+- Prefer text-only coder MoE models with strong native tool-calling and large
+  context. Current pick: `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit`
+  (~32 GB, `Qwen3MoeForCausalLM`, 262,144 native context, `rope_scaling: null`).
+- A single resident model maximizes the KV/prefix-cache budget under the wired
+  ceiling; co-residency of two large models roughly halves it.
+- Will **not** fit 128 GB: `Qwen3-Coder-480B-A35B` (~540 GB @ 8-bit), Kimi K2.x
+  (192 GB+). Rule these out early.
+- Re-verify exact HF repo IDs + `config.json` at decision time — MLX repos appear
+  and update frequently.
+
+### Apple Silicon memory
+
+- `iogpu.wired_limit_mb` (MB; the macOS Sonoma 14+ key — older OS used
+  `debug.iogpu.wired_limit` in bytes). Set: `sudo sysctl iogpu.wired_limit_mb=98304`.
+- On hosts ≥64 GB, macOS already allows ~75% wired by default; pinning the value
+  prevents dynamic shrink under load. 96 GB on a 128 GB host leaves ~32 GB for macOS.
+- The value is **not** persistent across reboot, and `/etc/sysctl.conf` is
+  unreliable on Apple Silicon — use a root **LaunchDaemon** that runs the sysctl at boot.
+- M5 Max: up to 128 GB unified memory, up to 614 GB/s (40-core GPU). MoE models with
+  ~3B active params decode fast under that bandwidth.
+- Apple does not officially document this knob; rely on tested community practice and
+  re-confirm per macOS release.
+
+## How you work
+
+1. Establish the exact target: chip, RAM, macOS version, oMLX version, model.
+2. For any external fact (flag spelling, repo existence/size, `config.json`, sysctl
+   behavior), consult first-party sources — the oMLX repo/README, the HF model
+   repo's `config.json`, Apple docs — via web search/fetch. Do not assert from memory.
+3. Give concrete, copy-pasteable config with its rationale and the failure mode it avoids.
+4. Flag anything that could only be confirmed by actually loading the model/server on the host.
+
+I never create, write, or edit files — I return advice and exact commands for the caller to apply.
+
+## Output format
+
+Recommendation (concise) → exact config/command → rationale + failure-mode it avoids →
+any verify-before-trust caveat. Cite first-party sources for external claims.
+
+## Constraints
+
+- Read-only/advisory: tools limited to read, search, web — no edit or execute.
+- No MCP servers, ever (project and framework policy).
+- Re-verify model availability and CLI flags against current first-party docs before
+  recommending a download or a config change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,12 @@ requests that share long system prefixes, so **concurrent throughput and
 prefix-cache reuse matter more than single-stream tok/s**.
 
 The authoritative brief is [`macos/local-llm-mac-os-creation.md`](macos/local-llm-mac-os-creation.md);
-the decision record is [`adrs/003-vlm-engine-workaround-lineup.md`](adrs/003-vlm-engine-workaround-lineup.md)
-(model lineup + engine override), which supersedes
-[`adrs/002-qwen36-lineup-memory-guard.md`](adrs/002-qwen36-lineup-memory-guard.md)
-(whose `--memory-guard-gb` migration and memory budget carry forward) and, through
-it, [`adrs/001-local-mlx-inference-omlx.md`](adrs/001-local-mlx-inference-omlx.md)
+the decision record is [`adrs/004-single-text-only-model-no-override.md`](adrs/004-single-text-only-model-no-override.md)
+(single text-only model, override retired), which supersedes
+[`adrs/003-vlm-engine-workaround-lineup.md`](adrs/003-vlm-engine-workaround-lineup.md)
+and, through it, [`adrs/002-qwen36-lineup-memory-guard.md`](adrs/002-qwen36-lineup-memory-guard.md)
+(whose `--memory-guard-gb` migration, wired limit, and concurrency carry forward)
+and [`adrs/001-local-mlx-inference-omlx.md`](adrs/001-local-mlx-inference-omlx.md)
 (whose runtime choice carries forward).
 `omlx-setup-prompt.md` is retained only as the historical source prompt; do not
 copy it forward as an additional source of truth.
@@ -26,9 +27,8 @@ copy it forward as an additional source of truth.
 The deliverable is `setup-omlx-m5.sh` (idempotent; author-side, run by the user):
 
 ```bash
-./setup-omlx-m5.sh                  # preflight + install + dirs + key + wired-limit + service + engine override (no model download)
-./setup-omlx-m5.sh --download-model # also fetch the primary model (~38 GB) via hf
-./setup-omlx-m5.sh --with-secondary # also fetch the secondary (~30 GB); implies --download-model
+./setup-omlx-m5.sh                  # preflight + install + dirs + key + wired-limit + service (no model download)
+./setup-omlx-m5.sh --download-model # also fetch the model (~32 GB) via hf
 ./setup-omlx-m5.sh --configure-pi   # register the oMLX provider with the Pi coding agent (~/.pi/agent/models.json)
 ./setup-omlx-m5.sh --validate       # endpoint checks (models / chat / tool-call / Anthropic / 2-way concurrency) against a running server
 ./setup-omlx-m5.sh --verbose --help
@@ -46,9 +46,10 @@ can still smoke-test deliberately.
 
 ## Hard constraints (project-specific)
 
-- **No MCP.** Do not install the oMLX `mcp` extra, add `mcp-servers` anywhere, or
-  reference MCP packages. Tool access stays explicit. (Reinforces the global
-  no-mcp-servers rule for this runtime specifically.)
+- **No MCP.** Do not enable oMLX's MCP support (a separate `pip install mcp` plus
+  `--mcp-config`), add `mcp-servers` anywhere, or reference MCP packages. Tool
+  access stays explicit. (Reinforces the global no-mcp-servers rule for this
+  runtime specifically.)
 - **API key.** Generate it locally, store at `~/.omlx/api-key` with `chmod 600`.
   Never print it or commit it.
 - **Idempotent.** Re-running the setup must detect and skip what already exists.
@@ -66,23 +67,21 @@ best-current-model review.
 
 - **Runtime:** oMLX via Homebrew —
   `brew tap jundot/omlx https://github.com/jundot/omlx && brew install omlx`
-- **Primary model:** Qwen3.6-35B-A3B at 8-bit MLX
-  (`mlx-community/Qwen3.6-35B-A3B-8bit`; MoE, ~3B active → fast decode under the
-  614 GB/s bandwidth cap; 8-bit preserves tool-call JSON fidelity). ~38 GB
-  resident. Pin + alias as `coding-fast`. **Engine override required:** the
-  checkpoint carries a `vision_config`, so oMLX would route it to the VLM
-  engine, which crashes under concurrent requests (oMLX #1800) — the setup
-  script sets `model_type_override = llm` via the admin API (ADR-003).
-- **Secondary (optional):** Qwen3-Coder-30B-A3B-Instruct at 8-bit MLX
-  (`lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit`, ~30 GB, verified
-  text-only → concurrency-safe without an override; 40K native context). Alias
-  `coding-quality`. Serves as the guaranteed-safe fan-out fallback if the
-  primary's engine override fails its concurrency probe.
+- **Model (single, text-only):** Qwen3-Coder-30B-A3B-Instruct at 8-bit MLX
+  (`lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit`; `Qwen3MoeForCausalLM`,
+  MoE ~3B active → fast decode under the 614 GB/s bandwidth cap; 8-bit preserves
+  tool-call JSON fidelity; 262,144-token native context, `rope_scaling` null).
+  ~32 GB resident. Pin + alias as `coding-fast`. **No engine override:** it is
+  verified text-only, so oMLX routes it to the batched LLM engine and it is
+  concurrency-safe as-is (ADR-004). A single resident model keeps the whole
+  KV/prefix-cache budget free for the fan-out — dropping a co-resident second
+  model is the deliberate reason there is only one (ADR-004).
 - **Serving flags:** `--host 127.0.0.1` (explicit loopback pin), port `8000`,
   `--memory-guard-gb 90` (replaces the removed `--max-process-memory`),
-  `--paged-ssd-cache-dir ~/.omlx/cache`, `--hot-cache-max-size 18GB` (absolute
-  size only — oMLX rejects percentages; ≈ the original 20%-of-guard intent),
-  `--max-concurrent-requests 16`, `--api-key` from the 0600 file.
+  `--paged-ssd-cache-dir ~/.omlx/cache`, `--hot-cache-max-size 18GB` (oMLX accepts
+  both absolute sizes and percentages; we pin an absolute value ≈ 20% of the guard
+  for a deterministic footprint), `--max-concurrent-requests 16` (oMLX default is
+  8), `--api-key` from the 0600 file.
 - **Metal wired limit:** raise `iogpu.wired_limit_mb` to ~96 GB (98304); persist
   across reboot via a LaunchDaemon (sudo).
 - **Autostart:** per-user LaunchAgent running a start wrapper that carries the tuned
@@ -90,27 +89,45 @@ best-current-model review.
 
 ## Layout
 
-- `setup-omlx-m5.sh` — the provisioning script. Installs oMLX (no MCP extra);
+- `setup-omlx-m5.sh` — the provisioning script. Installs oMLX (no MCP);
   creates `~/models`, `~/.omlx/{cache,logs,bin}`; generates the 0600 API key;
   sets + persists the wired limit; installs the start wrapper + LaunchAgent;
-  applies the primary's `llm` engine override via the admin API;
   **model download is opt-in (default off)**; `--configure-pi` registers the
-  provider with the Pi coding agent.
+  provider with the Pi coding agent. No engine override step — the model is
+  text-only (ADR-004).
 - `templates/` — committed templates the script installs with placeholder
   substitution: `omlx-start-wrapper.sh`, the `com.local.omlx.plist` LaunchAgent,
   the `com.local.iogpu-wired-limit.plist` root LaunchDaemon, and
   `pi-models-omlx.json` (the Pi coding-agent provider block).
-- `adrs/` — `003-vlm-engine-workaround-lineup.md` records the current convention
-  (superseding `002`, which superseded `001`); `TEMPLATE.md` is the MADR
-  minimal template for new ADRs (sequential, zero-padded three digits).
+- `.claude/agents/omlx-expert.md` + `.github/agents/omlx-expert.agent.md` —
+  repository-resident `omlx-expert` domain agent (oMLX runtime + MLX model
+  selection + Apple-Silicon memory tuning), read-only/advisory, in both Claude
+  Code and GitHub Copilot wrapper formats. Keep the two wrappers in sync.
+- `adrs/` — `004-single-text-only-model-no-override.md` records the current
+  convention (superseding `003`, which superseded `002`, which superseded `001`);
+  `TEMPLATE.md` is the MADR minimal template for new ADRs (sequential, zero-padded
+  three digits).
 - `docs/router-wiring.md` — wiring the server into the .NET `IInferenceBackend` /
   `FallbackInferenceRouter`.
+- `README.md` — the public-facing quickstart (clone → run → validate → connect).
+  Keep it in sync when flags, model IDs, or the step order change.
+
+### Script architecture (read before editing `setup-omlx-m5.sh`)
+
+The script is **error-accumulating, not fail-fast**. Only the preflight gate
+exits hard (code `2`); every other step reports failures through `record_err`
+(bumps `error_count`, exit `1` at the end) or `record_warn` (bumps `warn_count`,
+non-fatal) and keeps going, so a single broken step does not abort the rest of
+provisioning. The run ends with the standard summary block (`PASS`/`FAIL`).
+Steps are independent functions gated by the `DO_*` flags from argument parsing;
+each is idempotent (detects and skips what already exists). Templates in
+`templates/` are installed via `render_template`, which does literal placeholder
+substitution — edit the template file, not the rendered output.
 
 ### Runtime artifacts (created on the host, never committed)
 
 - `~/.omlx/` (chmod 700) containing `api-key` (0600), `bin/omlx-start-wrapper.sh`,
-  `cache/`, `logs/`, `pi-provider-snippet.json` (rendered by `--configure-pi`),
-  `model_settings.json` (oMLX-managed; holds the `llm` engine override), and
+  `cache/`, `logs/`, `pi-provider-snippet.json` (rendered by `--configure-pi`), and
   `settings.json` (oMLX-managed; **contains a copy of the API key** at
   `.auth.api_key` because oMLX persists its CLI args — the script chmods it 0600)
 - `~/models/` — downloaded MLX model directories
@@ -124,18 +141,19 @@ best-current-model review.
 
 After the server is up, validate against `http://localhost:8000/v1` (the script's
 `--validate` mode runs all five):
+
 1. `GET /v1/models` with the API key.
 2. A small `/v1/chat/completions` call.
 3. A **tool-calling** call confirming the model emits well-formed `tool_call`
    markup — the orchestrator depends on this; flag if the parser needs config.
-4. A **2-way concurrency probe** (two parallel completions) — the regression
-   gate for the primary's `llm` engine override; a broken override crashes the
-   VLM engine on the second concurrent request (oMLX #1800, ADR-003).
+4. A **2-way concurrency probe** (two parallel completions) — a general health
+   check that the batched LLM engine handles the fan-out this project serves.
 5. A `POST /v1/messages` call confirming the Anthropic-style endpoint is reachable.
 
 Anthropic-style clients use `/v1/messages`. The downstream consumer is an
-`IInferenceBackend` / `FallbackInferenceRouter`: route `coding-fast` → primary,
-`coding-quality` → secondary (if installed).
+`IInferenceBackend` / `FallbackInferenceRouter`: `coding-fast` → this local model;
+the `coding-quality` role has no local model and falls through to a remote backend
+(see `docs/router-wiring.md`).
 
 ## Teardown
 
@@ -153,9 +171,9 @@ sudo rm -f /Library/LaunchDaemons/com.local.iogpu-wired-limit.plist
 # 3. Uninstall oMLX
 brew uninstall omlx && brew untap jundot/omlx
 
-# 4. Remove data (the API key + cache/logs, and the large models)
+# 4. Remove data (the API key + cache/logs, and the model)
 rm -rf ~/.omlx          # includes the 0600 api-key
-rm -rf ~/models/Qwen3.6-35B-A3B-8bit ~/models/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit
+rm -rf ~/models/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit
 ```
 
 ## Scripts

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You need: an Apple Silicon Mac with **128 GB unified memory** (tuned for M5 Max;
 
 ```bash
 git clone https://github.com/psmfd/local-llm.git && cd local-llm
-./setup-omlx-m5.sh --download-model   # install + configure + fetch the primary model (~38 GB)
+./setup-omlx-m5.sh --download-model   # install + configure + fetch the model (~32 GB)
 ./setup-omlx-m5.sh --validate         # smoke-test the running server
 ```
 
@@ -21,27 +21,25 @@ The script is idempotent — re-running it skips whatever already exists. Run `.
 `setup-omlx-m5.sh` performs, in order:
 
 1. **Preflight** — hard-fails (exit `2`) on non-macOS, non-arm64, <~120 GB RAM, <~100 GB free disk, or missing Homebrew.
-2. **Installs oMLX** via `brew tap jundot/omlx && brew install omlx` (no MCP extra — tool access stays explicit).
+2. **Installs oMLX** via `brew tap jundot/omlx && brew install omlx` (no MCP — tool access stays explicit).
 3. **Creates directories** — `~/models`, `~/.omlx/{cache,logs,bin}` (`~/.omlx` is chmod 700).
 4. **Generates an API key** at `~/.omlx/api-key` (chmod 600, never printed).
-5. **Raises the Metal wired limit** to ~96 GB so the GPU can hold a large model resident, persisted across reboots via a root LaunchDaemon (**the sudo step**).
+5. **Raises the Metal wired limit** to ~96 GB so the GPU can hold the model resident, persisted across reboots via a root LaunchDaemon (**the sudo step**).
 6. **Installs autostart** — a start wrapper carrying the tuned serving flags plus a per-user LaunchAgent.
-7. **Applies the engine override** for the primary model (`model_type_override = llm`) via the admin API — required because the checkpoint carries a `vision_config` that would otherwise route it to oMLX's VLM engine, which crashes under concurrent load ([oMLX #1800](https://github.com/jundot/omlx/issues/1800), [ADR-003](adrs/003-vlm-engine-workaround-lineup.md)).
 
-Model download is **opt-in** (`--download-model` / `--with-secondary`); the base run never pulls weights.
+Model download is **opt-in** (`--download-model`); the base run never pulls weights. No engine override is applied — the model is text-only, so oMLX runs it on its batched LLM engine and it is concurrency-safe as-is ([ADR-004](adrs/004-single-text-only-model-no-override.md)).
 
-## Models
+## Model
 
-| Alias | Model | Size | Role |
+| Alias | Model | Size | Notes |
 |---|---|---|---|
-| `coding-fast` | `mlx-community/Qwen3.6-35B-A3B-8bit` (MoE, ~3 B active) | ~38 GB | Primary — fast decode, 8-bit preserves tool-call JSON fidelity |
-| `coding-quality` | `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` | ~30 GB | Optional secondary (`--with-secondary`) — verified text-only, the concurrency-safe fallback |
+| `coding-fast` | `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` (MoE, ~3 B active) | ~32 GB | Verified text-only (`Qwen3MoeForCausalLM`), 262 K native context, 8-bit preserves tool-call JSON fidelity, concurrency-safe with no override |
 
-Re-verify the HuggingFace repo IDs against current availability before downloading — the script probes them, but better checkpoints ship often. Pinning + aliasing is done in the admin panel at `http://localhost:8000/admin` (the script prints the manual steps).
+A single resident model keeps the full KV/prefix-cache budget free for the parallel-agent fan-out. The `coding-quality` router role has no local model and falls through to a remote backend (see [docs/router-wiring.md](docs/router-wiring.md)). Re-verify the HuggingFace repo ID against current availability before downloading — the script probes it, but better checkpoints ship often. Pinning + aliasing is done in the admin panel at `http://localhost:8000/admin` (the script prints the manual steps).
 
 ## Validating
 
-`./setup-omlx-m5.sh --validate` runs five checks against the running server: model listing, a small chat completion, a **tool-calling** round-trip, a **2-way concurrency probe** (the regression gate for the engine override), and an Anthropic-style `/v1/messages` call.
+`./setup-omlx-m5.sh --validate` runs five checks against the running server: model listing, a small chat completion, a **tool-calling** round-trip, a **2-way concurrency probe** (confirms the batched engine handles the fan-out), and an Anthropic-style `/v1/messages` call.
 
 ## Connecting clients
 
@@ -57,7 +55,8 @@ Re-verify the HuggingFace repo IDs against current availability before downloadi
 | [`setup-omlx-m5.sh`](setup-omlx-m5.sh) | The provisioning script (idempotent; exit codes `0` pass / `1` error / `2` precondition) |
 | [`templates/`](templates/) | Start wrapper, LaunchAgent/LaunchDaemon plists, Pi provider block — installed with placeholder substitution |
 | [`macos/local-llm-mac-os-creation.md`](macos/local-llm-mac-os-creation.md) | The authoritative implementation brief |
-| [`adrs/`](adrs/) | Decision records — [ADR-003](adrs/003-vlm-engine-workaround-lineup.md) is current (model lineup + engine override) |
+| [`adrs/`](adrs/) | Decision records — [ADR-004](adrs/004-single-text-only-model-no-override.md) is current (single text-only model, override retired) |
+| `.claude/agents/`, `.github/agents/` | Repository-resident `omlx-expert` domain agent (read-only/advisory) for Claude Code and GitHub Copilot |
 | [`docs/router-wiring.md`](docs/router-wiring.md) | Wiring the server into a .NET `IInferenceBackend` / `FallbackInferenceRouter` |
 | [`omlx-setup-prompt.md`](omlx-setup-prompt.md) | Historical source prompt only — not a source of truth |
 
@@ -71,7 +70,7 @@ rm -f ~/Library/LaunchAgents/com.local.omlx.plist
 sudo launchctl bootout system/com.local.iogpu-wired-limit 2>/dev/null || true
 sudo rm -f /Library/LaunchDaemons/com.local.iogpu-wired-limit.plist
 brew uninstall omlx && brew untap jundot/omlx
-rm -rf ~/.omlx ~/models/Qwen3.6-35B-A3B-8bit ~/models/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit
+rm -rf ~/.omlx ~/models/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit
 ```
 
 ## Security notes

--- a/adrs/003-vlm-engine-workaround-lineup.md
+++ b/adrs/003-vlm-engine-workaround-lineup.md
@@ -1,6 +1,6 @@
 # ADR-003: Force the LLM engine for the VLM-classified primary; swap the secondary to a text-only coder
 
-- Status: accepted
+- Status: superseded by ADR-004
 - Date: 2026-06-11
 
 Supersedes [ADR-002](002-qwen36-lineup-memory-guard.md) for the model lineup

--- a/adrs/004-single-text-only-model-no-override.md
+++ b/adrs/004-single-text-only-model-no-override.md
@@ -1,0 +1,82 @@
+# ADR-004: Drop to a single text-only model; retire the VLM engine override
+
+- Status: accepted
+- Date: 2026-06-22
+
+Supersedes [ADR-003](003-vlm-engine-workaround-lineup.md) for the model lineup
+and removes the engine-override requirement it introduced. ADR-002's flag
+migration (`--memory-guard-gb 90`), wired limit (96 GB), concurrency (16), and
+the runtime choice from ADR-001 all carry forward unchanged.
+
+## Context and Problem Statement
+
+ADR-003 kept the natively-multimodal `mlx-community/Qwen3.6-35B-A3B-8bit` as the
+primary and forced it onto the batched LLM engine via `model_type_override = llm`
+to dodge the VLM-engine concurrency crash (oMLX #1800). A first-party
+re-verification on 2026-06-22 confirmed three things: (1) #1800 is still open and
+unfixed (v0.4.4); (2) **every** MLX repack of Qwen3.6-35B-A3B carries the trap —
+the `unsloth/Qwen3.6-35B-A3B-MLX-8bit` alternative is *also* mlx-vlm-packaged
+(`vision_config`, `Qwen3VLProcessor`, `Qwen3_5MoeForConditionalGeneration`), an
+equal-or-stronger VLM-routing signal — because the base model ships a vision
+tower; (3) the secondary, `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit`,
+is verified text-only (`Qwen3MoeForCausalLM`, no `vision_config`, **262,144**-token
+native context with `rope_scaling: null` — not the 40,960 ADR-003 recorded) and is
+concurrency-safe with no override. The override path is therefore unproven,
+fragile (it rides an open upstream bug), and — given a fully-safe coder model
+exists — unnecessary. Do we keep paying for it?
+
+## Considered Options
+
+- **Keep ADR-003's hybrid** (35B primary + override, 30B-Coder secondary). Best
+  raw model size, but the concurrent path depends on an open upstream bug and an
+  admin-API override that drifts with oMLX's young CLI surface.
+- **Swap roles** (30B-Coder primary, 35B override-bearing secondary). Makes the
+  default path override-free, but keeps the override machinery alive for a
+  fallback that is now the *riskier* model — an inversion of the safety story, and
+  two co-resident models (~70 GB) halve the KV/prefix-cache budget.
+- **Single text-only model (chosen).** Ship only
+  `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` as `coding-fast`.
+  Delete the override step, the `--with-secondary` flag, and the secondary
+  download/provider wiring. No larger text-only coder fits 128 GB cleanly
+  (Qwen3-Coder-480B ≈ 540 GB, Kimi K2.x needs 192 GB+), so a second local model
+  buys little for a coding fan-out.
+
+## Decision Outcome
+
+Chosen option: **single text-only model**. The only model is
+`lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` (~32 GB,
+`Qwen3MoeForCausalLM`, 262,144 native context, coder-instruct-tuned, strong
+native tool-calling), alias `coding-fast`. The setup script no longer applies any
+engine override, no longer offers `--with-secondary`, and the `--validate`
+two-way concurrency probe is retained as a general batched-engine health check
+(no longer an override regression gate). The `coding-quality` role is no longer
+backed locally; the downstream `FallbackInferenceRouter` falls through to a remote
+backend for it (see `docs/router-wiring.md`).
+
+This ADR also records three documentation corrections from the same
+re-verification: `--hot-cache-max-size` accepts **both** absolute sizes and
+percentages (oMLX docs) — the prior "absolute only / rejects percentages" claim
+was wrong; the chosen model's native context is **262,144**, not 40,960; and oMLX
+MCP support is enabled via a separate `pip install mcp` + `--mcp-config`, not a
+package "extra" marker (the no-MCP policy is unchanged).
+
+### Consequences
+
+- Good, because the concurrent path is override-free and rides no open upstream
+  bug — the whole `model_type_override` / admin-API-probe surface is deleted.
+- Good, because a single ~32 GB resident model leaves ~64 GB under the 96 GB
+  wired ceiling for KV and prefix cache across the 16-way fan-out (vs ~26 GB when
+  two large models were co-resident) — more concurrent throughput and prefix
+  reuse, the project's stated priority. This also opens headroom to later raise
+  `--hot-cache-max-size` or `--max-concurrent-requests` if measurement warrants.
+- Good, because the model is purpose-built for coding with strong tool-calling
+  and a 262K native context — long-context work no longer needs a separate model.
+- Bad / accepted trade-offs:
+  - No local "quality" tier — `coding-quality` depends on a remote fallback. If a
+    larger *text-only* coder that fits 128 GB ships later, add it back as a
+    secondary under a new ADR.
+  - The general vision capability of the 35B is forgone (irrelevant for this
+    text/code workload).
+  - Revisit if the workload shows the 30B-Coder is under-powered for the
+    "quality" role, or if mlx-vlm PR #1354 (#1800's fix) merges and makes the
+    multimodal Qwen3.6 builds concurrency-safe without an override.

--- a/docs/router-wiring.md
+++ b/docs/router-wiring.md
@@ -9,9 +9,11 @@ oMLX and falling through to a remote backend on failure or saturation.
   OpenAI chat-completions shape.
 - **Auth:** bearer key read once at startup from `OMLX_API_KEY`, else from the
   0600 file `~/.omlx/api-key`. **Never hardcode the key.**
-- **Aliases:** the `model` field carries the oMLX alias — `coding-fast`
-  (primary) or `coding-quality` (secondary). Aliases are set in the `/admin` panel
-  (see [ADR-002](../adrs/002-qwen36-lineup-memory-guard.md)).
+- **Aliases:** the `model` field carries the oMLX alias. This host serves only
+  `coding-fast` (the single local model); `coding-quality` is intentionally **not**
+  backed locally and falls through to a remote backend (see
+  [ADR-004](../adrs/004-single-text-only-model-no-override.md)). The alias is set in
+  the `/admin` panel.
 - **Concurrency:** typed `HttpClient` via `IHttpClientFactory` +
   `AddStandardResilienceHandler` so a local hiccup degrades into the fallback
   router rather than throwing.
@@ -228,10 +230,12 @@ builder.Services.AddTransient<FallbackInferenceRouter>();
 - **Order = priority.** Register oMLX first; the router iterates registration
   order, so the local backend is primary for every role. It catches
   `InferenceUnavailableException` and advances to the next backend.
-- **Role routing.** Both roles map through the alias dictionary. If `coding-quality`
-  is not installed, oMLX errors for that model → wrapped as
-  `InferenceUnavailableException` → fallback. No startup "is it installed?" check
-  needed.
+- **Role routing.** Both roles map through the alias dictionary. `coding-quality`
+  is intentionally not served locally (single-model host, ADR-004): oMLX errors for
+  that model → wrapped as `InferenceUnavailableException` → fallback to the next
+  backend. No startup "is it installed?" check needed. (If you prefer the local
+  model to answer both roles, point `ModelRole.Quality` at `coding-fast` in the
+  alias dictionary.)
 - **Saturation.** oMLX runs at `--max-concurrent-requests 16`; a 429 trips the
   circuit breaker, diverting traffic to the remote backend until it recovers.
 

--- a/setup-omlx-m5.sh
+++ b/setup-omlx-m5.sh
@@ -12,9 +12,7 @@
 #   ./setup-omlx-m5.sh [options]
 #
 # Options:
-#   --download-model   Download the PRIMARY model (~38 GB) via `hf download`.
-#   --with-secondary   Also download the SECONDARY model (~30 GB). Implies
-#                      --download-model. Off by default.
+#   --download-model   Download the model (~32 GB) via `hf download`. Off by default.
 #   --configure-pi     Register the oMLX provider with the Pi coding agent.
 #                      Auto-writes ~/.pi/agent/models.json ONLY when its
 #                      providers object is empty (backup taken first);
@@ -73,24 +71,22 @@ WIRED_LIMIT_MB=98304    # 96 GB; leaves ~32 GB for macOS on a 128 GB host (ADR-0
 WIRED_MIN_MB=90000      # wrapper warns below this
 
 MIN_RAM_GB=120
-MIN_DISK_GB=100         # ~61 GB of models plus paged-SSD cache headroom (ADR-002)
+MIN_DISK_GB=100         # ~32 GB model plus paged-SSD cache headroom (ADR-004)
 
-# Repo IDs verified against the HuggingFace API on 2026-06-11 (ADR-003). Re-probed
-# before every download, but still confirm the best current model before large
-# downloads. The primary checkpoint carries a vision_config, so oMLX would route
-# it to the VLM engine, which crashes under concurrent requests (oMLX #1800) —
-# apply_model_override forces it onto the batched LLM engine. The secondary is a
-# verified text-only coder build and is concurrency-safe without an override.
-PRIMARY_REPO="mlx-community/Qwen3.6-35B-A3B-8bit"
-PRIMARY_DIR="$MODELS_DIR/Qwen3.6-35B-A3B-8bit"
+# Repo ID verified against the HuggingFace config.json on 2026-06-22 (ADR-004).
+# Re-probed before every download, but still confirm the best current model before
+# large downloads. The model is a verified text-only coder build
+# (Qwen3MoeForCausalLM, no vision_config) → it routes to oMLX's batched LLM engine
+# and is concurrency-safe with NO engine override. A single resident model keeps
+# the whole KV/prefix-cache budget under the wired ceiling for the fan-out.
+PRIMARY_REPO="lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit"
+PRIMARY_DIR="$MODELS_DIR/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit"
 PRIMARY_ALIAS="coding-fast"
-SECONDARY_REPO="lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit"
-SECONDARY_DIR="$MODELS_DIR/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit"
-SECONDARY_ALIAS="coding-quality"
 
 # Pi coding-agent provider registration (--configure-pi). contextWindow is half
-# the primary's 262K native context: 16 concurrent sessions at full context
-# would overrun the KV/wired budget and collapse prefix-cache reuse (ADR-003).
+# the model's 262144-token native context (verified config.json, rope_scaling
+# null): 16 concurrent sessions at full context would overrun the KV/wired budget
+# and collapse prefix-cache reuse (ADR-004).
 PI_AGENT_DIR="${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}"
 PI_CONTEXT_WINDOW=131072
 PI_MAX_TOKENS=16384
@@ -102,7 +98,6 @@ AGENT_PLIST="$HOME/Library/LaunchAgents/${AGENT_LABEL}.plist"
 WRAPPER_PATH="$BIN_DIR/omlx-start-wrapper.sh"
 
 DO_DOWNLOAD=false
-DO_SECONDARY=false
 DO_VALIDATE=false
 DO_CONFIGURE_PI=false
 OMLX_PRESENT=false   # set by install_omlx; gates whether the LaunchAgent is started
@@ -116,7 +111,6 @@ usage() { awk 'NR==1{next} /^#/{sub(/^# ?/,"");print;next} {exit}' "${BASH_SOURC
 while [ $# -gt 0 ]; do
     case "$1" in
         --download-model) DO_DOWNLOAD=true ;;
-        --with-secondary) DO_DOWNLOAD=true; DO_SECONDARY=true ;;
         --configure-pi)   DO_CONFIGURE_PI=true ;;
         --validate)       DO_VALIDATE=true ;;
         --verbose)        VERBOSE=true ;;
@@ -134,6 +128,18 @@ preflight() {
         err "preflight" "not macOS (uname -s = $(uname -s))"; exit 2
     fi
     ok "preflight" "macOS detected"
+
+    # oMLX's documented support floor appears to be macOS 15 (Sequoia); this is a
+    # third-party signal, not first-party, so warn rather than hard-fail. Note the
+    # major version jumped to 26 (Tahoe) in 2025, so anything >= 15 is current.
+    local osver osmajor
+    osver="$(sw_vers -productVersion 2>/dev/null || echo 0)"
+    osmajor="${osver%%.*}"
+    if [ "${osmajor:-0}" -lt 15 ]; then
+        record_warn "preflight" "macOS ${osver} is below 15 (Sequoia) — oMLX may require 15.0+; proceeding"
+    else
+        ok "preflight" "macOS ${osver}"
+    fi
 
     if [ "$(uname -m)" != "arm64" ]; then
         err "preflight" "not Apple Silicon (uname -m = $(uname -m))"; exit 2
@@ -349,7 +355,7 @@ check_omlx_cli() {
         record_err "omlx-cli" "failed to inspect '$omlx_bin serve --help' — verify the oMLX CLI before starting the LaunchAgent"
         return 1
     fi
-    for flag in --model-dir --port --memory-guard-gb --paged-ssd-cache-dir --hot-cache-max-size --max-concurrent-requests --api-key; do
+    for flag in --host --model-dir --port --memory-guard-gb --paged-ssd-cache-dir --hot-cache-max-size --max-concurrent-requests --api-key; do
         if ! printf '%s\n' "$help_text" | grep -q -- "$flag"; then
             record_err "omlx-cli" "'omlx serve --help' does not advertise expected flag: $flag"
             missing=true
@@ -512,76 +518,10 @@ download_model() {
 
 maybe_download_models() {
     if ! $DO_DOWNLOAD; then
-        skip "model" "download is opt-in — re-run with --download-model (and --with-secondary), or use the /admin downloader (verify the exact quant tags first)"
+        skip "model" "download is opt-in — re-run with --download-model, or use the /admin downloader (verify the exact quant tags first)"
         return
     fi
-    download_model "$PRIMARY_REPO" "$PRIMARY_DIR" "model-primary"
-    if $DO_SECONDARY; then
-        download_model "$SECONDARY_REPO" "$SECONDARY_DIR" "model-secondary"
-    fi
-}
-
-# --- Step: force the primary onto the batched LLM engine (ADR-003) ----------
-# The primary checkpoint carries a vision_config, so oMLX auto-classifies it as
-# VLM — and the VLM engine crashes on any second concurrent request (oMLX
-# #1800, unfixed). Setting model_type_override=llm per model forces the
-# batched text engine. Needs a running server that has discovered the model,
-# so this step degrades to a warning plus the manual /admin instruction.
-apply_model_override() {
-    local model_id; model_id="$(basename "$PRIMARY_DIR")"
-    local manual="Manual step: in http://localhost:${PORT}/admin set Model Type Override = llm for ${model_id} (required for concurrent requests; oMLX #1800 / ADR-003)"
-
-    if [ ! -r "$API_KEY_FILE" ]; then
-        record_warn "override" "API key file not readable — cannot reach the admin API yet"
-        info "$manual"
-        return
-    fi
-    local key; key="$(cat "$API_KEY_FILE")"
-    local auth="Authorization: Bearer ${key}"
-
-    # The admin API mount prefix has drifted between oMLX versions; probe both.
-    local base settings_url=""
-    for base in "http://localhost:${PORT}/admin/api" "http://localhost:${PORT}/api"; do
-        if curl -fsS --max-time 10 -H "$auth" "${base}/models/${model_id}/settings" >/dev/null 2>&1; then
-            settings_url="${base}/models/${model_id}/settings"
-            break
-        fi
-    done
-    if [ -z "$settings_url" ]; then
-        record_warn "override" "model-settings API unreachable for ${model_id} — server down or model not yet present"
-        info "$manual"
-        return
-    fi
-
-    local current
-    current="$(curl -fsS --max-time 10 -H "$auth" "$settings_url" 2>/dev/null || true)"
-    if printf '%s' "$current" | grep -q '"model_type_override"[[:space:]]*:[[:space:]]*"llm"'; then
-        skip "override" "${model_id} already pinned to the llm (batched) engine"
-        return
-    fi
-
-    # Merge into the existing settings object rather than PUTting a bare field,
-    # in case the endpoint replaces the whole settings document.
-    local payload
-    payload="$(printf '%s' "$current" | python3 -c '
-import json, sys
-try:
-    d = json.load(sys.stdin)
-    if not isinstance(d, dict):
-        d = {}
-except Exception:
-    d = {}
-d["model_type_override"] = "llm"
-print(json.dumps(d))
-' 2>/dev/null)" || payload='{"model_type_override":"llm"}'
-
-    if curl -fsS --max-time 10 -X PUT -H "$auth" -H 'Content-Type: application/json' \
-        -d "$payload" "$settings_url" >/dev/null 2>&1; then
-        ok "override" "${model_id} forced onto the llm (batched) engine — validate with the concurrency probe"
-    else
-        record_warn "override" "PUT to ${settings_url} failed"
-        info "$manual"
-    fi
+    download_model "$PRIMARY_REPO" "$PRIMARY_DIR" "model"
 }
 
 # --- Step: Pi coding-agent provider registration (--configure-pi) -----------
@@ -591,11 +531,10 @@ print(json.dumps(d))
 # parse shows an empty providers object (backup taken first; git covers the
 # rest). Anything else gets the rendered snippet plus manual merge steps.
 print_pi_settings_instructions() {
-    local settings_file="$1" primary_id="$2" secondary_id="$3"
+    local settings_file="$1" primary_id="$2"
     # settings.json is hand-curated and git-tracked; never edited automatically.
-    info "To surface the models in Pi's picker, add to the enabledModels array in $settings_file:"
+    info "To surface the model in Pi's picker, add to the enabledModels array in $settings_file:"
     echo "      \"omlx/${primary_id}\""
-    echo "      \"omlx/${secondary_id}\"   (if the secondary is installed)"
     echo "      Select with: pi --model omlx/${primary_id}  (or /model in a session — models.json reloads on /model)"
 }
 
@@ -614,24 +553,15 @@ configure_pi_provider() {
     local models_file="$PI_AGENT_DIR/models.json"
     local settings_file="$PI_AGENT_DIR/settings.json"
     local snippet_dest="$OMLX_HOME/pi-provider-snippet.json"
-    local primary_id secondary_id secondary_entry=""
+    local primary_id
     primary_id="$(basename "$PRIMARY_DIR")"
-    secondary_id="$(basename "$SECONDARY_DIR")"
-
-    # Register the secondary when requested this run or already on disk.
-    if $DO_SECONDARY || { [ -d "$SECONDARY_DIR" ] && [ -n "$(ls -A "$SECONDARY_DIR" 2>/dev/null)" ]; }; then
-        # Flat single-line JSON: render_template substitutes via BSD sed, which
-        # cannot carry literal newlines in the replacement value.
-        secondary_entry=", {\"id\": \"${secondary_id}\", \"name\": \"${SECONDARY_ALIAS} (local oMLX)\", \"reasoning\": false, \"input\": [\"text\"], \"contextWindow\": ${PI_CONTEXT_WINDOW}, \"maxTokens\": ${PI_MAX_TOKENS}, \"cost\": {\"input\": 0, \"output\": 0, \"cacheRead\": 0, \"cacheWrite\": 0}}"
-    fi
 
     if render_template "$TEMPLATE_DIR/pi-models-omlx.json" "$snippet_dest" \
-        "__PORT__"                  "$PORT" \
-        "__API_KEY_FILE__"          "$API_KEY_FILE" \
-        "__PRIMARY_ID__"            "$primary_id" \
-        "__PI_CONTEXT_WINDOW__"     "$PI_CONTEXT_WINDOW" \
-        "__PI_MAX_TOKENS__"         "$PI_MAX_TOKENS" \
-        "__SECONDARY_MODEL_ENTRY__" "$secondary_entry"; then
+        "__PORT__"              "$PORT" \
+        "__API_KEY_FILE__"      "$API_KEY_FILE" \
+        "__PRIMARY_ID__"        "$primary_id" \
+        "__PI_CONTEXT_WINDOW__" "$PI_CONTEXT_WINDOW" \
+        "__PI_MAX_TOKENS__"     "$PI_MAX_TOKENS"; then
         ok "pi-config" "rendered provider snippet: $snippet_dest"
     else
         case "$?" in
@@ -643,7 +573,7 @@ configure_pi_provider() {
     # Idempotency: never rewrite a models.json that already names this provider.
     if [ -f "$models_file" ] && grep -q '"omlx"' "$models_file"; then
         skip "pi-config" "\"omlx\" provider already present in $models_file (left untouched)"
-        print_pi_settings_instructions "$settings_file" "$primary_id" "$secondary_id"
+        print_pi_settings_instructions "$settings_file" "$primary_id"
         return
     fi
 
@@ -683,7 +613,7 @@ PYEOF
         info "Insert the \"omlx\" block from $snippet_dest into the providers object of $models_file"
     fi
 
-    print_pi_settings_instructions "$settings_file" "$primary_id" "$secondary_id"
+    print_pi_settings_instructions "$settings_file" "$primary_id"
 }
 
 # --- Pin/alias instructions (GUI-only; cannot be scripted) ------------------
@@ -693,11 +623,8 @@ print_pin_instructions() {
     info "Model pin + alias is admin-panel only (not a CLI flag). Manual steps:"
     echo "      1. Ensure the server is running, then open http://localhost:${PORT}/admin"
     echo "      2. Under Models, set the alias for $(basename "$PRIMARY_DIR") to '${PRIMARY_ALIAS}' and PIN it (keeps it resident)."
-    if $DO_SECONDARY; then
-        echo "      3. Set the alias for $(basename "$SECONDARY_DIR") to '${SECONDARY_ALIAS}'."
-    fi
-    echo "      Aliases persist in ${OMLX_HOME}/settings.json and appear in GET /v1/models."
-    echo "      Confirm Model Type Override = llm on $(basename "$PRIMARY_DIR") if the scripted override warned (oMLX #1800; ADR-003)."
+    echo "      The alias persists in ${OMLX_HOME}/settings.json and appears in GET /v1/models."
+    echo "      No engine override is needed — the model is text-only (Qwen3MoeForCausalLM); ADR-004."
 }
 
 # --- Validation -------------------------------------------------------------
@@ -749,18 +676,18 @@ validate_endpoint() {
         record_err "validate-tools" "tool-calling request failed"
     fi
 
-    # 4. concurrency probe — two parallel completions. The VLM engine crashes on
-    # a second concurrent request (oMLX #1800); model_type_override=llm is the
-    # fix (ADR-003). A single-stream validate cannot catch a broken override.
+    # 4. concurrency probe — two parallel completions confirm the batched LLM
+    # engine handles the fan-out this project exists to serve. A single-stream
+    # check cannot detect a server that serializes or fails under concurrency.
     local pid1 pid2 rc1=0 rc2=0
     curl -fsS -H "$auth" -H 'Content-Type: application/json' -d "$chat_req" "${base}/chat/completions" >/dev/null 2>&1 & pid1=$!
     curl -fsS -H "$auth" -H 'Content-Type: application/json' -d "$chat_req" "${base}/chat/completions" >/dev/null 2>&1 & pid2=$!
     wait "$pid1" || rc1=$?
     wait "$pid2" || rc2=$?
     if [ "$rc1" -eq 0 ] && [ "$rc2" -eq 0 ]; then
-        ok "validate-concurrent" "2 parallel completions succeeded (batched engine confirmed)"
+        ok "validate-concurrent" "2 parallel completions succeeded (batched engine handles concurrency)"
     else
-        record_err "validate-concurrent" "parallel completions failed (rc ${rc1}/${rc2}) — likely oMLX #1800: set Model Type Override = llm for the primary in /admin (ADR-003)"
+        record_err "validate-concurrent" "parallel completions failed (rc ${rc1}/${rc2}) — check --max-concurrent-requests and the server logs ($LOG_DIR)"
     fi
 
     # 5. Anthropic-style messages endpoint (spec requires /v1/messages reachability)
@@ -790,7 +717,6 @@ summary() {
 main() {
     if $DO_VALIDATE; then
         command -v curl >/dev/null 2>&1 || { err "validate" "curl not found"; exit 2; }
-        apply_model_override
         validate_endpoint
         summary
     fi
@@ -805,7 +731,6 @@ main() {
     install_wired_limit
     install_service
     maybe_download_models
-    apply_model_override
     if $DO_CONFIGURE_PI; then
         configure_pi_provider
     else

--- a/templates/omlx-start-wrapper.sh
+++ b/templates/omlx-start-wrapper.sh
@@ -58,9 +58,9 @@ fi
 # saturation surfaces as server-level backpressure, not Metal wiring failures. It
 # replaced the removed --max-process-memory flag (ADR-002); per oMLX #702 it
 # monitors Metal allocations, not total RSS.
-# --hot-cache-max-size takes an absolute size only ('8GB' style) — parse_size in
-# 0.4.4rc1 rejects percentages, crash-looping the agent. 18GB ≈ the original
-# 20%-of-guard intent.
+# --hot-cache-max-size accepts both absolute sizes ('18GB') and percentages
+# ('20%'). We pin an absolute 18GB for a deterministic hot-cache footprint
+# independent of how oMLX resolves a percentage (≈ 20% of the 90 GB guard).
 # --host pins the loopback bind explicitly so "local-only" does not depend on an
 # upstream default (one oMLX config class defaults to 0.0.0.0).
 exec "__BREW_PREFIX__/bin/omlx" serve \

--- a/templates/pi-models-omlx.json
+++ b/templates/pi-models-omlx.json
@@ -13,12 +13,12 @@
 //   supportsUsageInStreaming: false — streaming usage stats not guaranteed
 //
 // Model ids are the canonical oMLX model directory names (NOT the /admin
-// aliases) — see ADR-003; switch to aliases only after validating the alias
+// aliases) — see ADR-004; switch to aliases only after validating the alias
 // round-trip on the installed oMLX version.
 //
-// contextWindow is held to 131072 (half the primary's 262K native context):
-// 16 concurrent sessions at full context would overrun the KV/wired budget
-// and collapse prefix-cache reuse.
+// contextWindow is held to 131072 (half the model's 262144-token native
+// context): 16 concurrent sessions at full context would overrun the KV/wired
+// budget and collapse prefix-cache reuse.
 {
   "providers": {
     "omlx": {
@@ -40,7 +40,7 @@
           "contextWindow": __PI_CONTEXT_WINDOW__,
           "maxTokens": __PI_MAX_TOKENS__,
           "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
-        }__SECONDARY_MODEL_ENTRY__
+        }
       ]
     }
   }


### PR DESCRIPTION
## Summary

Reconciles the provisioning project against current first-party documentation (verified 2026-06-22) and simplifies the runtime. A parallel research fan-out confirmed the central VLM-engine concurrency trap is real and that every MLX repack of Qwen3.6-35B-A3B (mlx-community **and** unsloth) carries it, while the text-only `Qwen3-Coder-30B-A3B-Instruct` is concurrency-safe with no override. We therefore drop to a single text-only model and retire the engine-override machinery, which also frees the full KV/prefix-cache budget for the parallel-agent fan-out. Adds a repository-resident `omlx-expert` domain agent for both Claude Code and GitHub Copilot.

## Type of Change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change

## Key changes

- **Model lineup → single text-only model.** `coding-fast` = `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` (verified `Qwen3MoeForCausalLM`, no `vision_config`, 262144 native context). Removed `apply_model_override`, `--with-secondary`, and the secondary download/provider wiring.
- **New `omlx-expert` agent**, read-only/advisory, in `.claude/agents/omlx-expert.md` and `.github/agents/omlx-expert.agent.md` (one combined agent per the cross-platform prescription; no SKILL.md, no `mcp-servers`).
- **Factual corrections**: `--hot-cache-max-size` accepts percentages *and* absolute sizes; native context is 262144 (not 40960); MCP is enabled via `pip install mcp` + `--mcp-config`, not a package extra; `--max-concurrent-requests` default is 8.
- **Preflight**: macOS >= 15 warning; `--host` added to the CLI flag-existence check.
- **ADR-004** records the decision and supersedes ADR-003.

## Test Plan

- `bash -n` on both shell files: clean.
- `shellcheck` (default + `-S warning`): clean.
- `markdownlint-cli2`: the actionable findings (MD036/MD032 in the new agent files, MD032 in CLAUDE.md) fixed; remaining are line-length / frontmatter classes the project's linter suppresses, plus pre-existing MD060 table-spacing convention.
- `templates/pi-models-omlx.json` renders to valid JSON after placeholder substitution.
- Verified `max_position_embeddings: 262144`, `rope_scaling: null`, `Qwen3MoeForCausalLM` against the model's first-party `config.json`.
- No live-host run (no M5 Max in CI); `./setup-omlx-m5.sh --validate` is the operator smoke test once a server is up.

## Doc-impact (per documentation-in-plan)

All in-scope surfaces updated in this PR: the two agent wrappers; `setup-omlx-m5.sh` + `templates/{omlx-start-wrapper.sh,pi-models-omlx.json}`; `adrs/004-*` (new) and the ADR-003 status header; `CLAUDE.md`; `README.md`; `docs/router-wiring.md` (moved in-scope once the secondary was dropped, since `coding-quality` is no longer backed locally and now falls through to a remote backend).

## Checklist

- [x] No secrets, API keys, or tokens committed.
- [x] No MCP servers / `mcp-servers` frontmatter introduced; tool access is explicit allowlists.
- [x] Cross-platform agent parity (Claude Code + Copilot wrappers in sync).
- [x] ADR added for the convention change (ADR-004; ADR-003 superseded, body untouched).
- [x] shellcheck clean; linter findings addressed.
