### PR TITLE
feat(setup): restore multi-tier co-resident model lineup (ADR-006)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,13 +12,16 @@ requests that share long system prefixes, so **concurrent throughput and
 prefix-cache reuse matter more than single-stream tok/s**.
 
 The authoritative brief is [`macos/local-llm-mac-os-creation.md`](macos/local-llm-mac-os-creation.md);
-the decision record is [`adrs/004-single-text-only-model-no-override.md`](adrs/004-single-text-only-model-no-override.md)
-(single text-only model, override retired), which supersedes
-[`adrs/003-vlm-engine-workaround-lineup.md`](adrs/003-vlm-engine-workaround-lineup.md)
-and, through it, [`adrs/002-qwen36-lineup-memory-guard.md`](adrs/002-qwen36-lineup-memory-guard.md)
+the current model-lineup decision is [`adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md`](adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md)
+(two co-resident pinned tiers + one on-demand max tier; stay on oMLX), which
+supersedes [`adrs/004-single-text-only-model-no-override.md`](adrs/004-single-text-only-model-no-override.md)
+and, through it, [`adrs/003-vlm-engine-workaround-lineup.md`](adrs/003-vlm-engine-workaround-lineup.md)
+and [`adrs/002-qwen36-lineup-memory-guard.md`](adrs/002-qwen36-lineup-memory-guard.md)
 (whose `--memory-guard-gb` migration, wired limit, and concurrency carry forward)
 and [`adrs/001-local-mlx-inference-omlx.md`](adrs/001-local-mlx-inference-omlx.md)
-(whose runtime choice carries forward).
+(whose oMLX runtime choice is reaffirmed by ADR-006). The full investigation —
+runtime reassessment, on-host bake-off, and tier selection — is in
+[`docs/runtime-tiering-research.md`](docs/runtime-tiering-research.md).
 `omlx-setup-prompt.md` is retained only as the historical source prompt; do not
 copy it forward as an additional source of truth.
 
@@ -43,9 +46,11 @@ omlxctl restart  # atomic restart + wait         |  omlxctl status  # launchd + 
 ```
 
 Exit codes: `0` pass, `1` errors, `2` precondition failure. Lint with the
-`linter` agent (shellcheck). The Metal wired-limit step needs `sudo`. Pinning +
-aliasing is **admin-panel only** at `http://localhost:8000/admin` — the script
-prints the manual steps; it cannot script them.
+`linter` agent (shellcheck). The Metal wired-limit step needs `sudo`. Aliases +
+pins are applied via the **oMLX admin API** (`apply_pins` briefly starts the
+server, PUTs each tier's settings, then stops it — `model_settings.json` is
+oMLX-owned, so the script never writes it directly); it degrades to printed
+manual admin-panel steps if the API can't be reached (ADR-006).
 
 Preflight hard-fails with exit `2` for non-macOS, non-arm64, RAM below ~120 GB,
 free disk below ~100 GB, or missing Homebrew. M5 Max is the tuned target; a
@@ -75,15 +80,20 @@ best-current-model review.
 
 - **Runtime:** oMLX via Homebrew —
   `brew tap jundot/omlx https://github.com/jundot/omlx && brew install omlx`
-- **Model (single, text-only):** Qwen3-Coder-30B-A3B-Instruct at 8-bit MLX
-  (`lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit`; `Qwen3MoeForCausalLM`,
-  MoE ~3B active → fast decode under the 614 GB/s bandwidth cap; 8-bit preserves
-  tool-call JSON fidelity; 262,144-token native context, `rope_scaling` null).
-  ~32 GB resident. Pin + alias as `coding-fast`. **No engine override:** it is
-  verified text-only, so oMLX routes it to the batched LLM engine and it is
-  concurrency-safe as-is (ADR-004). A single resident model keeps the whole
-  KV/prefix-cache budget free for the fan-out — dropping a co-resident second
-  model is the deliberate reason there is only one (ADR-004).
+- **Models (three tiers, all text-only; ADR-006):** every tier is a verified
+  text-only coder build (`*ForCausalLM`, no `vision_config`) and tool-call-verified
+  on oMLX, so each routes to the batched LLM engine with **no engine override**.
+  - **T1 `coding-fast`** — `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit`
+    (`Qwen3MoeForCausalLM`, MoE ~3B active, 262K ctx). ~30.6 GB. **Pinned, co-resident.**
+  - **T2 `coding-balanced`** — `mlx-community/GLM-4.7-Flash-8bit`
+    (`Glm4MoeLiteForCausalLM`, MoE ~3B active, 202K ctx). ~30 GB. **Pinned, co-resident.**
+  - **MAX `coding-quality`** — `lmstudio-community/Qwen3-Coder-Next-MLX-4bit`
+    (`Qwen3NextForCausalLM`, 80B/~3B active, ~71% SWE-bench). ~45 GB. **On-demand**
+    (lazy-loads ~16 s on first request, idle-evicts; NOT pinned — it does not
+    co-reside alongside T1+T2 under the wired ceiling).
+  T1+T2 stay co-resident (~60 GB) leaving ~29 GB for KV/prefix cache under the
+  96 GB wired ceiling, so the fan-out never pays a swap cost. DFlash SSD cache is
+  disabled on every tier (oMLX #702/#1892).
 - **Serving flags:** `--host 127.0.0.1` (explicit loopback pin), port `8000`,
   `--memory-guard-gb 90` (replaces the removed `--max-process-memory`),
   `--paged-ssd-cache-dir ~/.omlx/cache`, `--hot-cache-max-size 18GB` (oMLX accepts
@@ -107,9 +117,11 @@ best-current-model review.
   creates `~/models`, `~/.omlx/{cache,logs,bin}`; generates the 0600 API key;
   sets + persists the wired limit; installs the start wrapper + LaunchAgent (on-
   demand, RunAtLoad=false) + the `omlxctl` control tool (symlinked onto PATH when
-  the brew bin is writable); **model download is opt-in (default off)**; leaves the
-  server stopped; `--configure-pi` registers the provider with the Pi coding agent.
-  No engine override step — the model is text-only (ADR-004).
+  the brew bin is writable); downloads the three tiers when **download is opt-in
+  (default off)**, skipping any already present (upgrade-safe); applies aliases +
+  pins via the admin API (`apply_pins`, start→pin→stop) and leaves the server
+  stopped; `--configure-pi` registers the provider with the Pi coding agent.
+  No engine override step — all tiers are text-only (ADR-006).
 - `templates/` — committed templates the script installs with placeholder
   substitution: `omlx-start-wrapper.sh`, the `com.local.omlx.plist` LaunchAgent,
   the `com.local.iogpu-wired-limit.plist` root LaunchDaemon, `omlxctl` (the
@@ -119,11 +131,13 @@ best-current-model review.
   repository-resident `omlx-expert` domain agent (oMLX runtime + MLX model
   selection + Apple-Silicon memory tuning), read-only/advisory, in both Claude
   Code and GitHub Copilot wrapper formats. Keep the two wrappers in sync.
-- `adrs/` — `004-single-text-only-model-no-override.md` records the current model
-  convention (superseding `003`, which superseded `002`, which superseded `001`);
-  `005-on-demand-service-lifecycle.md` records the on-demand start/stop lifecycle
-  (no login autostart) — additive, not a supersession of `004`; `TEMPLATE.md` is the
-  MADR minimal template for new ADRs (sequential, zero-padded three digits).
+- `adrs/` — `006-multi-tier-coresident-lineup-stay-on-omlx.md` records the current
+  model lineup (superseding `004`, which superseded `003` → `002` → `001`; the
+  `--memory-guard-gb`/wired-limit/concurrency from `002` and the oMLX runtime from
+  `001` carry forward); `005-on-demand-service-lifecycle.md` records the on-demand
+  start/stop lifecycle (no login autostart) — additive, still in force under `006`;
+  `TEMPLATE.md` is the MADR minimal template for new ADRs (sequential, zero-padded
+  three digits). The decision rationale lives in `docs/runtime-tiering-research.md`.
 - `docs/router-wiring.md` — wiring the server into the .NET `IInferenceBackend` /
   `FallbackInferenceRouter`.
 - `README.md` — the public-facing quickstart (clone → run → validate → connect).
@@ -171,9 +185,10 @@ After the server is up, validate against `http://localhost:8000/v1` (the script'
 5. A `POST /v1/messages` call confirming the Anthropic-style endpoint is reachable.
 
 Anthropic-style clients use `/v1/messages`. The downstream consumer is an
-`IInferenceBackend` / `FallbackInferenceRouter`: `coding-fast` → this local model;
-the `coding-quality` role has no local model and falls through to a remote backend
-(see `docs/router-wiring.md`).
+`IInferenceBackend` / `FallbackInferenceRouter`: `coding-fast` and `coding-balanced`
+→ co-resident local models; `coding-quality` → the local on-demand max tier
+(Qwen3-Coder-Next, lazy-loaded), with a remote backend as fallback (see
+`docs/router-wiring.md`).
 
 ## Teardown
 
@@ -193,9 +208,11 @@ sudo rm -f /Library/LaunchDaemons/com.local.iogpu-wired-limit.plist
 # 3. Uninstall oMLX
 brew uninstall omlx && brew untap jundot/omlx
 
-# 4. Remove data (the API key + cache/logs, and the model)
+# 4. Remove data (the API key + cache/logs, and the three model tiers)
 rm -rf ~/.omlx          # includes the 0600 api-key
-rm -rf ~/models/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit
+rm -rf ~/models/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit \
+       ~/models/GLM-4.7-Flash-8bit \
+       ~/models/Qwen3-Coder-Next-MLX-4bit
 ```
 
 ## Scripts

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Stand up a **local, OpenAI/Anthropic-compatible LLM inference server** on an App
 
 ## TL;DR — start now
 
-You need: an Apple Silicon Mac with **128 GB unified memory** (tuned for M5 Max; other Max-class chips warn but work), ~100 GB free disk, macOS, and [Homebrew](https://brew.sh). One step needs `sudo` (GPU wired-memory limit).
+You need: an Apple Silicon Mac with **128 GB unified memory** (tuned for M5 Max; other Max-class chips warn but work), ~140 GB free disk (three model tiers ≈ 105 GB plus cache headroom), macOS, and [Homebrew](https://brew.sh). One step needs `sudo` (GPU wired-memory limit).
 
 ```bash
 git clone https://github.com/psmfd/local-llm.git && cd local-llm
-./setup-omlx-m5.sh --download-model   # install + configure + fetch the model (~32 GB)
+./setup-omlx-m5.sh --download-model   # install + configure + fetch the 3 tiers (~105 GB)
 omlxctl start                         # start the server on demand (NOT at login)
 ./setup-omlx-m5.sh --validate         # smoke-test the running server
 ```
@@ -30,15 +30,19 @@ The script is idempotent — re-running it skips whatever already exists. Run `.
 5. **Raises the Metal wired limit** to ~96 GB so the GPU can hold the model resident, persisted across reboots via a root LaunchDaemon (**the sudo step**).
 6. **Installs on-demand service control** — a start wrapper carrying the tuned serving flags, a per-user LaunchAgent (`RunAtLoad=false`, `KeepAlive=false` — registered at login but **not** started), and the `omlxctl` control tool (symlinked onto your `PATH` when the Homebrew bin is writable). Setup deliberately leaves the server stopped ([ADR-005](adrs/005-on-demand-service-lifecycle.md)).
 
-Model download is **opt-in** (`--download-model`); the base run never pulls weights. No engine override is applied — the model is text-only, so oMLX runs it on its batched LLM engine and it is concurrency-safe as-is ([ADR-004](adrs/004-single-text-only-model-no-override.md)).
+Model download is **opt-in** (`--download-model`); the base run never pulls weights. No engine override is applied — every tier is a verified text-only coder build, so oMLX runs each on its batched LLM engine and it is concurrency-safe as-is ([ADR-006](adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md)).
 
-## Model
+## Model tiers
 
-| Alias | Model | Size | Notes |
-|---|---|---|---|
-| `coding-fast` | `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` (MoE, ~3 B active) | ~32 GB | Verified text-only (`Qwen3MoeForCausalLM`), 262 K native context, 8-bit preserves tool-call JSON fidelity, concurrency-safe with no override |
+Three tiers ([ADR-006](adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md)), all verified text-only (no `vision_config`) and tool-call-verified on oMLX:
 
-A single resident model keeps the full KV/prefix-cache budget free for the parallel-agent fan-out. The `coding-quality` router role has no local model and falls through to a remote backend (see [docs/router-wiring.md](docs/router-wiring.md)). Re-verify the HuggingFace repo ID against current availability before downloading — the script probes it, but better checkpoints ship often. Pinning + aliasing is done in the admin panel at `http://localhost:8000/admin` (the script prints the manual steps).
+| Tier | Alias | Model | ~Size | Residency |
+|---|---|---|---|---|
+| fast | `coding-fast` | `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` (MoE, ~3 B active, 262 K ctx) | ~30 GB | pinned, co-resident |
+| balanced | `coding-balanced` | `mlx-community/GLM-4.7-Flash-8bit` (MoE-lite, ~3 B active, 202 K ctx) | ~30 GB | pinned, co-resident |
+| quality | `coding-quality` | `lmstudio-community/Qwen3-Coder-Next-MLX-4bit` (MoE, 80 B/~3 B active, ~71 % SWE-bench) | ~45 GB | on-demand (lazy-load ~16 s, idle-evicts) |
+
+`coding-fast` + `coding-balanced` stay **co-resident and pinned** (~60 GB, leaving ~29 GB for KV/prefix cache under the 96 GB wired ceiling), so the parallel-agent fan-out never pays a swap cost. `coding-quality` is the genuine high-fidelity tier — it does not co-reside (45 GB + 60 GB exceeds the budget), so oMLX **lazy-loads it on first request** and evicts it when idle. The setup script applies aliases + pins via the oMLX admin API (briefly starting the server, then stopping it; falls back to printed manual steps). Re-verify the HuggingFace repo IDs against current availability before downloading — the script probes them, but better checkpoints ship often.
 
 ## Starting and stopping
 
@@ -74,10 +78,23 @@ After a reboot or login, run `omlxctl start` to bring the server back.
 | [`setup-omlx-m5.sh`](setup-omlx-m5.sh) | The provisioning script (idempotent; exit codes `0` pass / `1` error / `2` precondition) |
 | [`templates/`](templates/) | Start wrapper, LaunchAgent/LaunchDaemon plists, `omlxctl` control tool, Pi provider block — installed with placeholder substitution |
 | [`macos/local-llm-mac-os-creation.md`](macos/local-llm-mac-os-creation.md) | The authoritative implementation brief |
-| [`adrs/`](adrs/) | Decision records — [ADR-004](adrs/004-single-text-only-model-no-override.md) (single text-only model) and [ADR-005](adrs/005-on-demand-service-lifecycle.md) (on-demand lifecycle, no login autostart) |
+| [`adrs/`](adrs/) | Decision records — current model lineup is [ADR-006](adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md) (two co-resident pinned tiers + one on-demand max tier, stay on oMLX; supersedes [ADR-004](adrs/004-single-text-only-model-no-override.md)) and [ADR-005](adrs/005-on-demand-service-lifecycle.md) (on-demand lifecycle, no login autostart) |
 | `.claude/agents/`, `.github/agents/` | Repository-resident `omlx-expert` domain agent (read-only/advisory) for Claude Code and GitHub Copilot |
 | [`docs/router-wiring.md`](docs/router-wiring.md) | Wiring the server into a .NET `IInferenceBackend` / `FallbackInferenceRouter` |
+| [`docs/runtime-tiering-research.md`](docs/runtime-tiering-research.md) | Research note behind [ADR-006](adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md) — runtime reassessment, on-host bake-off, and tier selection |
 | [`omlx-setup-prompt.md`](omlx-setup-prompt.md) | Historical source prompt only — not a source of truth |
+
+## Upgrading from a single-model (ADR-004) install
+
+If you previously provisioned the single-model (ADR-004) lineup, just re-run the script — it is an in-place, non-destructive upgrade:
+
+```bash
+git pull
+./setup-omlx-m5.sh --download-model   # fetches only the 2 new tiers; the existing 30B is skipped
+./setup-omlx-m5.sh --validate         # confirms all three aliases resolve
+```
+
+The re-run detects the existing `coding-fast` model + pin, downloads only the missing `coding-balanced`/`coding-quality` tiers, and applies the new aliases/pins via the admin API (it briefly starts the server, then stops it). It never overwrites your API key, the oMLX-managed `model_settings.json` (it merges via the admin API), or a non-empty Pi config (a merge snippet is left at `~/.omlx/pi-provider-snippet.json`). Running it twice is a no-op.
 
 ## Teardown
 
@@ -91,7 +108,10 @@ rm -f "$(brew --prefix)/bin/omlxctl"                   # the on-PATH symlink, if
 sudo launchctl bootout system/com.local.iogpu-wired-limit 2>/dev/null || true
 sudo rm -f /Library/LaunchDaemons/com.local.iogpu-wired-limit.plist
 brew uninstall omlx && brew untap jundot/omlx
-rm -rf ~/.omlx ~/models/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit
+rm -rf ~/.omlx \
+  ~/models/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit \
+  ~/models/GLM-4.7-Flash-8bit \
+  ~/models/Qwen3-Coder-Next-MLX-4bit
 ```
 
 ## Security notes

--- a/adrs/004-single-text-only-model-no-override.md
+++ b/adrs/004-single-text-only-model-no-override.md
@@ -1,6 +1,6 @@
 # ADR-004: Drop to a single text-only model; retire the VLM engine override
 
-- Status: accepted
+- Status: superseded by [ADR-006](006-multi-tier-coresident-lineup-stay-on-omlx.md)
 - Date: 2026-06-22
 
 Supersedes [ADR-003](003-vlm-engine-workaround-lineup.md) for the model lineup

--- a/adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md
+++ b/adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md
@@ -1,0 +1,102 @@
+# ADR-006: Restore a multi-tier lineup — two co-resident pinned tiers + one on-demand max tier, staying on oMLX
+
+- Status: accepted
+- Date: 2026-06-24
+
+Supersedes [ADR-004](004-single-text-only-model-no-override.md) for the model
+lineup. **Reaffirms** [ADR-001](001-local-mlx-inference-omlx.md)'s runtime choice
+(oMLX) and adds an explicit **co-resident / pinned / no-swap** operating mode.
+ADR-002's flag migration (`--memory-guard-gb 90`), wired limit (96 GB),
+concurrency (`--max-concurrent-requests 16`), and the runtime from ADR-001 all
+carry forward unchanged. The full investigation behind this decision is recorded in
+[docs/runtime-tiering-research.md](../docs/runtime-tiering-research.md) (Parts 1–6),
+including an on-host bake-off on the M5 Max target.
+
+## Context and Problem Statement
+
+ADR-004 collapsed the lineup to a single text-only model, leaving the
+`coding-quality` role to a remote fallback. The operator now wants to restore a
+**3+ tier local lineup whose fidelity scales with the workload, selected
+automatically with no manual model loading**. Before building this, two things had
+to be settled: (1) is oMLX still the right runtime, or would switching unlock more
+capable models; and (2) what concrete tiers actually work — verified on the target
+hardware, not assumed?
+
+## Considered Options
+
+- **Keep ADR-004 (single text-only model).** Rejected: does not meet the multi-tier
+  goal.
+- **Switch runtime (llama.cpp / vllm-mlx) to escape the VLM trap and run the newest
+  multimodal models text-only.** Rejected (research Part 6): the VLM-trapped models
+  are not better *coders* (Gemma-3-27B ≈ half our LiveCodeBench; Qwen3.6-35B-A3B's
+  lead is scaffold-inflated, within-noise of Qwen3-Coder-Next), and the genuinely
+  stronger coders (Devstral-2-123B, Qwen3-Coder-480B, DeepSeek-V3) are **size-gated
+  by the 128 GB ceiling**, which no runtime fixes. Switching would forfeit the
+  MLX/M5 Neural-Accelerator speed path and re-open per-model tool-call verification
+  for ~no capability gain.
+- **oMLX native auto-swap (lazy load + LRU/TTL evict) as the steady-state tiering
+  mechanism.** Rejected: oMLX's open multi-model swap-path bugs (#1970 lock-during-
+  load blocks loaded models, #1938 memory-not-reclaimed, #514 stacked-OOM) plus the
+  intrinsic loss of the shared prefix cache on every swap make swapping hazardous
+  for the concurrent fan-out (research Parts 1, 3).
+- **Add a co-resident dense "quality" T3 (Devstral-Small-2507 or
+  Qwen2.5-Coder-32B).** Rejected empirically (research Part 5): both **fail
+  tool-calling on oMLX** — Devstral emits no parseable call (even
+  `tool_choice=required` ignored); Qwen2.5-Coder wraps calls in `<tools>` not
+  `<tool_call>`, so oMLX drops them. No co-resident dense ~30B candidate is both
+  strong at agentic coding and tool-clean on oMLX today.
+- **Two co-resident pinned tiers + one on-demand max tier (chosen).**
+
+## Decision Outcome
+
+Chosen option: **two co-resident, pinned, text-only tiers plus one on-demand "max"
+tier, all on oMLX, with no steady-state swapping**, because it delivers 3 tiers of
+fidelity-by-workload while keeping every tool-call path verified-working on oMLX and
+never exercising the buggy multi-model swap path.
+
+| Tier | Model | Quant | ~Resident | Tools on oMLX (verified) | Role |
+|---|---|---|---|---|---|
+| T1 fast | `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` (alias `coding-fast`) | 8-bit | ~30.6 GB | ✓ | general coding, tool chains |
+| T2 medium | `mlx-community/GLM-4.7-Flash-8bit` | 8-bit | ~30 GB | ✓ | fast tool relay / agentic |
+| Max | `lmstudio-community/Qwen3-Coder-Next-MLX-4bit` | 4-bit | ~45 GB | ✓ | high-fidelity (~71% SWE-bench); on-demand |
+
+- **T1 and T2 are co-resident and `is_pinned: true`**; combined ≈ 61 GB leaves
+  ~29 GB for KV/prefix cache under the 90 GB guard (96 GB Metal wired ceiling).
+  Verified: T1+T2 at 16-way concurrency returned 16/16.
+- **The "max" tier (Qwen3-Coder-Next) is on-demand** — oMLX lazy-loads it on first
+  request (~16 s) and it TTL-evicts when idle. It is **not** co-resident (45 GB +
+  61 GB > guard). Because it is hit rarely and T1/T2 stay pinned, the swap-path bug
+  exposure is bounded; this is the only place a load occurs in normal operation.
+- **DFlash SSD cache stays disabled** (oMLX #702 enforcer undercount, #1892
+  single-DFlash-model limit).
+- **Routing is by the request `model` field** (aliases/dir names); the downstream
+  .NET `FallbackInferenceRouter` is kept **runtime-agnostic** (one endpoint) so the
+  engine remains swappable if oMLX's swap-path bugs ever block a future need.
+- GLM-4.7-Flash measured at ~30 GB resident (the prior ~21 GB estimate was wrong).
+
+This satisfies "3+ tiers, fidelity-by-workload" (fast → tool-relay → high-fidelity
+on demand) with zero steady-state swapping.
+
+### Consequences
+
+- Good, because three fidelity tiers are available with **every tool path verified
+  on oMLX**, and the co-resident pair **never triggers** the open multi-model
+  swap-path bugs (nothing loads/evicts in steady state).
+- Good, because it keeps oMLX's MLX/M5 Neural-Accelerator speed path and block-level
+  prefix cache, and Qwen3-Coder-Next (~71% SWE-bench) is the genuine capability
+  ceiling for 128 GB — the strongest agentic coder that fits.
+- Good, because memory hygiene was verified (clean release on stop/kill; exo #1370
+  did not reproduce) and the lineup leaves generous KV headroom.
+- Bad / accepted trade-offs:
+  - **No co-resident dense "quality" tier** — every ~30B dense candidate either
+    fails tool-calling on oMLX or is a weak agentic coder. Add one later only if a
+    ~30B model ships that is both strong at agentic editing **and** tool-clean on
+    oMLX.
+  - The **max tier pays a ~16 s cold start** on its (rare) loads and carries
+    bounded #1970 exposure while loading under concurrent T1/T2 traffic.
+  - The runtime bet remains a young, ~single-maintainer project (oMLX) with open
+    bugs; mitigated by pinning + no-swap and the runtime-agnostic router.
+  - **Revisit triggers:** (a) the VLM trap — re-evaluate multimodal models if oMLX
+    bumps its bundled `mlx-vlm` past PR #1354 **and** the remaining batching bugs
+    (#1422, #1378) close; (b) a tool-clean co-resident dense coder shipping; (c) a
+    larger text-only coder that fits 128 GB.

--- a/docs/router-wiring.md
+++ b/docs/router-wiring.md
@@ -1,19 +1,21 @@
 # Wiring oMLX into the .NET `IInferenceBackend` / `FallbackInferenceRouter`
 
 This note shows how to register the local oMLX server as one `IInferenceBackend`
-behind your `FallbackInferenceRouter`, routing `coding-fast` (primary) →
-oMLX and falling through to a remote backend on failure or saturation.
+behind your `FallbackInferenceRouter`, routing the three local tiers
+(`coding-fast`, `coding-balanced`, `coding-quality`) → oMLX and falling through to
+a remote backend on failure or saturation.
 
 - **Endpoint:** `http://localhost:8000/v1` (OpenAI-style `POST /v1/chat/completions`).
   oMLX also serves Anthropic-style `POST /v1/messages`; this note uses the
   OpenAI chat-completions shape.
 - **Auth:** bearer key read once at startup from `OMLX_API_KEY`, else from the
   0600 file `~/.omlx/api-key`. **Never hardcode the key.**
-- **Aliases:** the `model` field carries the oMLX alias. This host serves only
-  `coding-fast` (the single local model); `coding-quality` is intentionally **not**
-  backed locally and falls through to a remote backend (see
-  [ADR-004](../adrs/004-single-text-only-model-no-override.md)). The alias is set in
-  the `/admin` panel.
+- **Aliases:** the `model` field carries the oMLX alias. This host serves three
+  tiers ([ADR-006](../adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md)):
+  `coding-fast` + `coding-balanced` are pinned co-resident; `coding-quality` is the
+  **on-demand** max tier (Qwen3-Coder-Next, lazy-loaded ~16 s on first request).
+  Keep a remote backend as the fallback after the local tiers. Aliases/pins are
+  applied by `setup-omlx-m5.sh` via the admin API.
 - **Concurrency:** typed `HttpClient` via `IHttpClientFactory` +
   `AddStandardResilienceHandler` so a local hiccup degrades into the fallback
   router rather than throwing.
@@ -27,7 +29,7 @@ oMLX and falling through to a remote backend on failure or saturation.
 ## Assumed contract
 
 ```csharp
-public enum ModelRole { Fast, Quality }
+public enum ModelRole { Fast, Balanced, Quality }
 public sealed record ChatMessage(string Role, string Content);
 public sealed record InferenceRequest(ModelRole Role, IReadOnlyList<ChatMessage> Messages, float? Temperature = null);
 public sealed record InferenceResponse(string Content, bool IsAvailable);
@@ -105,8 +107,9 @@ public sealed class OmlxInferenceBackend(HttpClient httpClient, ILogger<OmlxInfe
     // Logical role → oMLX model alias (the "model" field).
     private static readonly Dictionary<ModelRole, string> ModelAliases = new()
     {
-        [ModelRole.Fast]    = "coding-fast",
-        [ModelRole.Quality] = "coding-quality",
+        [ModelRole.Fast]     = "coding-fast",
+        [ModelRole.Balanced] = "coding-balanced",
+        [ModelRole.Quality]  = "coding-quality",   // on-demand: first call lazy-loads (~16 s)
     };
 
     // No global DefaultIgnoreCondition: the property-level [JsonIgnore] on the
@@ -230,12 +233,13 @@ builder.Services.AddTransient<FallbackInferenceRouter>();
 - **Order = priority.** Register oMLX first; the router iterates registration
   order, so the local backend is primary for every role. It catches
   `InferenceUnavailableException` and advances to the next backend.
-- **Role routing.** Both roles map through the alias dictionary. `coding-quality`
-  is intentionally not served locally (single-model host, ADR-004): oMLX errors for
-  that model → wrapped as `InferenceUnavailableException` → fallback to the next
-  backend. No startup "is it installed?" check needed. (If you prefer the local
-  model to answer both roles, point `ModelRole.Quality` at `coding-fast` in the
-  alias dictionary.)
+- **Role routing.** All three roles map through the alias dictionary to local oMLX
+  tiers (ADR-006). `coding-fast` and `coding-balanced` are pinned co-resident, so
+  they answer immediately. `coding-quality` (Qwen3-Coder-Next) is **on-demand**:
+  oMLX lazy-loads it on the first request (~16 s), so that call is slow — size the
+  resilience `AttemptTimeout` to tolerate it, or pre-warm with a throwaway request.
+  If a tier ever errors (e.g. transient load failure) it is wrapped as
+  `InferenceUnavailableException` → fallback to the next backend.
 - **Saturation.** oMLX runs at `--max-concurrent-requests 16`; a 429 trips the
   circuit breaker, diverting traffic to the remote backend until it recovers.
 

--- a/docs/runtime-tiering-research.md
+++ b/docs/runtime-tiering-research.md
@@ -1,0 +1,633 @@
+# Research: runtime choice & multi-tier model serving
+
+> **Status: LIVING / RESEARCH COMPLETE, DECISION PENDING** (2026-06-23). This is
+> a research reference note, **not** a decision record. The decision it feeds
+> will be captured in a new ADR (expected ADR-006, superseding
+> [ADR-004](../adrs/004-single-text-only-model-no-override.md), and revisiting
+> [ADR-001](../adrs/001-local-mlx-inference-omlx.md)'s runtime choice) once a
+> direction is chosen. Part 1 (oMLX auto-swap capability) and Part 2 (runtime
+> reassessment) are both complete.
+
+## Why this exists
+
+ADR-004 collapsed the lineup to a **single text-only model**
+(`lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit`, alias `coding-fast`),
+with the `coding-quality` role falling through to a remote backend. The operator
+now wants to **restore a multi-tier (3+) local lineup** where fidelity/quality
+scales with the workload, ideally **swapped automatically with zero developer
+interaction**. Before designing that on oMLX, we are reassessing whether oMLX is
+still the right foundation.
+
+### Goals (the criteria all findings are judged against)
+
+- **3+ fidelity tiers** (small → large), selected automatically by the request's
+  `model` field — no manual load/unload.
+- **Parallel-agent coding workload**: an orchestrator fans out 3+ concurrent
+  requests sharing long system prefixes. The dominant levers are **continuous /
+  in-flight batching** and **prefix-cache / KV reuse** across those concurrent
+  requests; single-stream tok/s is secondary.
+- OpenAI-compatible (`/v1/chat/completions`) + Anthropic-style (`/v1/messages`)
+  API; strong **tool-calling JSON fidelity**.
+
+### Hard constraints (carried from prior ADRs)
+
+- Host: Apple Silicon **M5 Max, 128 GB unified memory**; Metal wired limit
+  ~96 GB; `--memory-guard-gb 90`; `--max-concurrent-requests 16`.
+- **Text-only models only** (`*ForCausalLM`, no `vision_config`): oMLX routes any
+  vision-config model to a VLM engine that **crashes on concurrent requests**
+  (issue #1800). Prefer **8-bit** quant for tool-call fidelity.
+- No MCP.
+
+---
+
+## Part 1 — Can on-demand model swapping be fully automatic on oMLX? (COMPLETE)
+
+**Answer: yes, natively, with zero operator action — but auto-swap must be a
+*rare* path, not the steady state, for this concurrent workload.**
+
+### 1.1 oMLX is a single-process, multi-model `EnginePool`
+
+This is the key reframe: it is **not** a one-model-at-a-time server. One oMLX
+process can hold multiple models resident *and* lazily load/evict others. So
+"co-resident" and "swap" are not mutually exclusive — you get both at once.
+Source-verified against `engine_pool.py`, `model_settings.py`, `server.py`,
+`model_registry.py`:
+
+- **Lazy load on request** — `EnginePool.get_engine(model_id)`: if a registered
+  model is not resident, the request triggers an automatic load (admission flow:
+  project memory → evict LRU victims if needed → `_load_engine()`). No admin
+  click, no `omlxctl` call.
+- **Automatic eviction** — LRU under memory pressure (`_find_lru_victim()`, runs
+  synchronously inside `get_engine()`) **and** per-model idle TTL
+  (`check_ttl_expirations()`, polled every 1s).
+- **Pinning** — `is_pinned: true` exempts a model from both LRU and TTL.
+- **Lease protection** — in-flight requests (`in_use > 0`) cannot be evicted
+  mid-stream.
+- Models auto-discovered from `--model-dir` / `OMLX_MODEL_DIR`; routing resolves
+  the request `model` field via `pool.resolve_model_id()` (exact → case-insensitive
+  → profile names → `model_alias` scan → provider-prefix strip).
+
+### 1.2 Lifecycle config keys (complete)
+
+| Config | Location | Default | Semantics |
+|---|---|---|---|
+| `ttl_seconds` | per-model `ModelSettings` | `None` | auto-unload after N s idle; `None` = disabled |
+| `idle_timeout_seconds` | `GlobalSettings` | `None` | global TTL fallback; min 60 s |
+| `is_pinned` | per-model `ModelSettings` | `false` | exempt from TTL **and** LRU |
+| `--memory-guard` | CLI | `balanced` | ceiling tier: `safe`/`balanced`/`aggressive` |
+| `--memory-guard-gb` | CLI | — | custom ceiling in GB (we use `90`) |
+| `memory_guard_custom_ceiling_gb` | `settings.json` | `0.0` | persistent form of above |
+| `soft_threshold` / `hard_threshold` | `settings.json` | `0.85` / `0.95` | eviction trigger fractions |
+| `prefill_memory_guard` | `settings.json` | `true` | prefill-peak memory protection |
+
+There is **no `--max-loaded-models` cap** — the memory ceiling is the only
+admission gate. Admin REST API also exposes explicit
+`POST /admin/api/models/{id}/load` · `/unload`, `GET /admin/api/models`,
+`PUT .../settings`, `PUT /admin/api/global-settings`, `POST /admin/api/cache-probe`.
+
+### 1.3 The catch — why auto-swap must be the rare path here
+
+Two independent reasons make *swapping under concurrent load* hazardous for this
+workload:
+
+**(a) Open v0.4.x swap-path bugs (all relevant to a concurrent fan-out):**
+
+| Issue | State | Impact |
+|---|---|---|
+| **#1970** | open (2026-06-22) | `get_engine()` holds the asyncio lock for the **whole** model load → blocks inference on **already-loaded** models; HTTP 507 if all resident models are busy and nothing is evictable; 4–6× load degradation under concurrency |
+| **#1938** | open (2026-06-19) | memory not reclaimed after rapid load/unload cycling (impossible negative `freed`); needs server restart |
+| **#514** | open | "stacked models" — old model not always evicted before new loads → OOM |
+| **#702** | open | memory enforcer tracks only Metal allocations, undercounts SSD hot-cache → macOS jetsam SIGKILL |
+| **#1892** | open (2026-06-16) | only **one** Dflash SSD-cache model at a time in v0.4.x (regression) |
+| **#1800** | open (2026-06-10) | VLM engine crashes on concurrent requests → **text-only only** |
+
+**(b) Physics, regardless of bugs:** every *actual* swap evicts that model's
+KV/prefix cache (it is weight-specific, not reusable across models), and two
+concurrent requests for *different* unloaded tiers serialize behind 8–35 s loads.
+That destroys the prefix-cache reuse + concurrency the project exists to optimize.
+
+**Mitigations:** pin the hot tier(s) co-resident; size the co-resident set to fit
+under the 90 GB guard so swaps are rare; set conservative `ttl_seconds` on rarely
+used tiers; **avoid the Dflash SSD cache** (#702, #1892); track #1970/#1938.
+
+### 1.4 Memory math (M5 Max, ~90 GB guard, ~84–86 GB effective for weights+KV)
+
+| Lineup | Resident weights | KV/prefix headroom | Verdict |
+|---|---|---|---|
+| small (~9 GB) + 30B-A3B MoE (~32 GB) | ~41 GB | ~20+ GB | comfortable; both **pinned** |
+| + 14B dense (~16 GB) = 3 tiers | ~57 GB | tighter, viable | 3 tiers co-resident, **no swap ever** |
+| dense **70B Q8** (~74 GB) | maxes guard alone | none | **cannot co-reside** — the only tier that forces real swap or remote |
+
+8-bit ≈ 1 byte/param + ~5–10 % overhead. Cold-start (disk→ready, ~6–7 GB/s NVMe):
+~3–6 s (7–8B), ~8–15 s (30–34B), ~18–35 s (70B Q8).
+
+**Implication:** if the top tier is a strong **MoE** (current 30B-A3B, or a larger
+MoE at a fitting quant), all 3+ tiers co-reside and the swap tax is never paid.
+Auto-swap (and its bug exposure) is only required for a genuinely large **dense**
+local tier.
+
+---
+
+## Part 2 — Runtime reassessment: stay on oMLX vs switch (COMPLETE)
+
+### 2.1 The decision-forcing finding
+
+oMLX was chosen (ADR-001) for **batched concurrent throughput + block-level
+prefix-cache reuse** for the fan-out. In v0.4.x today, that exact subsystem —
+concurrent *multi-model* serving with SSD-tiered prefix cache — sits on four
+intersecting **open** bugs:
+
+| Issue | Hits |
+|---|---|
+| #1970 | asyncio lock held for the whole model load → blocks inference on already-loaded models; HTTP 507; 4–6× degradation under concurrency (filed 2026-06-22, no response) |
+| #1892 | DFlash SSD prefix cache works for **only one model at a time** → negates the multi-tier prefix-cache benefit |
+| #1938 | memory not reclaimed after load/unload cycling → server restart needed |
+| #514 | stacked-model OOM (old model not evicted) |
+
+Plus #702 (enforcer undercounts SSD cache → jetsam SIGKILL), #1800 (VLM engine
+crashes on concurrency → text-only only), and #95 (Metal command-buffer race on
+concurrent requests, per the runtime-matrix agent). **Project health is good; the
+specific feature surface we'd build on is not.**
+
+### 2.2 The gap that has closed
+
+oMLX's headline differentiator — cross-request shared-prefix KV reuse — is **no
+longer unique**. Apple's own **`mlx_lm.server`** (`ml-explore/mlx-lm`) has an
+`LRUPromptCache` trie shared across all concurrent requests in one process: a long
+shared system prompt is computed once and reused for every concurrent agent on
+that model — exactly the fan-out behavior we wanted, working correctly. It also
+has real continuous batching (`BatchGenerator`, `--decode-concurrency`,
+`--prompt-concurrency`). Caveat: **single-model only**, and Apple labels it "not
+production-ready."
+
+`llama-server` (llama.cpp) also gained a **native multi-model router**
+(`--models-max`, lazy autoload), **both** OpenAI and Anthropic endpoints, and true
+continuous batching — but llama.cpp **cannot use the M5 Neural Accelerators**
+(MLX-only), so it's ~1.4–1.8× slower on prefill, and its prefix cache is per-slot,
+not cross-request block-level.
+
+### 2.3 Runtime scorecard (for THIS workload)
+
+| Runtime | Multi-model zero-touch | Continuous batching | Cross-request prefix cache | M5 NPU path | API (OAI/Anthropic) | Liveliness / risk |
+|---|---|---|---|---|---|---|
+| **oMLX** | yes (EnginePool, lazy+LRU+TTL+pin) | yes | yes — **but broken under multi-model (#1970/#1892/#1938)** | yes (MLX) | both | Active; **High risk** for this workload |
+| **mlx_lm.server** | no (single-model) | yes | **yes (LRU trie, correct)** | yes (MLX) | OAI (+Anthropic via proxy) | Active (Apple); Low — but "not production-ready" |
+| **llama-server + llama-swap** | yes (router / llama-swap matrix) | yes | per-slot only; `-kvu` unified buffer | **no (GGUF/Metal, ~1.5× slower)** | both | Active; Low (llama.cpp), Low-Med (llama-swap) |
+| **Ollama** | yes (auto load/unload, TTL) | **no — queue/slot based** | limited (single-path trie) | yes (MLX backend, maturing) | both | Active; Medium |
+| **LM Studio** | yes | yes (open prefill-stall bug) | **not shared across concurrent** | yes (MLX) | both | Active; Medium |
+
+### 2.4 Lock-in / migration cost
+
+Low at the **API layer** (every alternative speaks `/v1/chat/completions`; the
+.NET router is unchanged), low at the **code layer**, **medium at the operational
+layer**: the admin-panel aliasing/TTL/pinning moves to startup flags or
+llama-swap YAML (more version-controllable anyway), launchd plists are re-pointed.
+Genuinely hard to replace: **DFlash SSD-tiered KV cache** (no alternative — but
+broken for multi-model in v0.4.x regardless) and the Anthropic prefix-cache token
+fields (`cache_creation_input_tokens` / `cache_read_input_tokens`) if anything
+upstream consumes them.
+
+### 2.5 Recommended target lineup (text-only, VLM-trap-screened, HF-verified)
+
+Disqualified by VLM trap or size (verified via `config.json`): the **entire
+Qwen3.6 series**, **Kimi K2.x** (multimodal + 1T), **Mistral-Small-3.2-24B**
+(VLM despite the name), **DeepSeek-V3 / Qwen3-Coder-480B** (text-only but
+≥270 GB).
+
+**Flavor 1 — all co-resident (~70 GB weights, no swap ever):**
+
+| Tier | Model | Quant | Repo | Weights |
+|---|---|---|---|---|
+| T1 fast | Qwen3-Coder-30B-A3B (current) | 8-bit | `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` | 32.4 GB |
+| T2 medium | GLM-4.7-Flash | 8-bit | `mlx-community/GLM-4.7-Flash-8bit` | ~21 GB |
+| T3 fidelity | DeepSeek-Coder-V2-Lite (or GLM-Z1-32B-4bit) | 8-bit | `mlx-community/DeepSeek-Coder-V2-Lite-Instruct-8bit` | 16.7 GB |
+
+**Flavor 2 — large top tier:** T1+T2 co-resident (~53 GB) + **Qwen3-Coder-Next**
+as T3 — 4-bit (`lmstudio-community/Qwen3-Coder-Next-MLX-4bit`, 44.8 GB, **70.6%
+SWE-bench**, all three co-fit at ~98 GB) or 8-bit (84.7 GB, solo/on-demand).
+Note: T3 here is `Qwen3NextForCausalLM` (hybrid attention) — see the unresolved
+claim in §2.7.
+
+### 2.6 Best-of-breed recommendation
+
+**Do not build the multi-tier auto-swap design deeper on oMLX.** Instead:
+
+1. **Insert a runtime-agnostic proxy now** (llama-swap) in front of the engine.
+   The .NET router targets the proxy and never changes again regardless of
+   backend. Anthropic `/v1/messages` passes through.
+2. **Prefer the co-resident lineup (Flavor 1) so swapping never happens.** Run
+   each tier as its own always-on **`mlx_lm.server`** process (correct
+   cross-request prefix cache + continuous batching + the MLX NPU speed path);
+   llama-swap routes by the `model` field. Three always-on processes at ~70 GB fit
+   the budget — this sidesteps BOTH oMLX's multi-model bugs AND llama-swap's
+   process-kill memory-release risk (no kills).
+3. **Only if a genuine large dense/Next top tier is required** (Flavor 2, 84.7 GB
+   solo) accept on-demand load + eviction, and **empirically validate Metal
+   memory actually releases on process kill** before relying on it (open risk
+   exo #1370).
+4. Keep **oMLX as a backend option behind the proxy** for single-model use (it is
+   correct for one-model-many-requests with pinning) and revisit if DFlash
+   multi-model support ships.
+
+This decouples the engine decision from the architecture permanently, delivers the
+prefix-cache behavior the project wanted **today**, and avoids the open-bug surface.
+
+### 2.7 Conflicts & unverified claims (carry into ADR-006 verification)
+
+- **oMLX maintainer concentration**: prior review said ~93% of commits are
+  jundot's; the critical-risk agent said ~40% with ~10 active contributors and
+  ~17k stars. **Conflict — re-check before citing.** Either way, bus-factor is the
+  weaker argument; the open multi-model bugs are the decisive one.
+- **oMLX hybrid-attention tool-call breakage**: the runtime-matrix agent claimed
+  oMLX mishandles tool-calls for hybrid-attention models (Qwen3.x / Gemma3 /
+  Llama4). **Unverified, single-source.** Material because T1 and the Flavor-2 T3
+  are Qwen3.x — verify directly (a tool-call round-trip on each candidate) before
+  finalizing the lineup/runtime.
+- **`mlx_lm.server` "not production-ready"** label — validate stability under the
+  16-way concurrent load before committing.
+- The three reassessment agents each opened with a hallucinated "all N agents
+  returned" preamble (they ran independently); their framing was discounted,
+  source-cited facts retained.
+
+### 2.8 Agent Efficacy Report (Part 2)
+
+| Agent | Type | Key contributions | Value |
+|---|---|---|---|
+| Runtime matrix | general-purpose | llama-server native router + dual API + M5-NPU/MLX speed gap; per-runtime scorecard & liveliness | High |
+| Critical risk review | general-purpose | Decision-forcing bug intersection; the closed gap (mlx_lm.server LRU trie); decisive hedge-with-llama-swap + mlx_lm.server-per-tier architecture; migration-cost layering | High |
+| Model lineup | general-purpose | config.json-verified text-only screening (killed the whole Qwen3.6/Kimi/Mistral-3.2 VLM set); two memory-budgeted 3-tier flavors with exact repo IDs | High |
+
+**Disagreements:** Runtime-matrix leaned "conditionally keep oMLX for
+full-attention models / use llama-server for max tool-call fidelity"; critical-risk
+leaned "hedge off the engine entirely via llama-swap + mlx_lm.server." Resolved in
+favor of the hedge — it satisfies both (oMLX *can* remain a backend) while removing
+the bug exposure. **Synergy:** matrix's NPU-speed finding + critical-risk's
+mlx_lm.server-prefix-cache finding + lineup's co-resident budget converge on
+"3 always-on mlx_lm.server tiers behind llama-swap, no swapping."
+
+---
+
+## Part 3 — Empirical verification on the M5 Max (bake-off)
+
+Run 2026-06-23 on the target host (Mac17,6 **Apple M5 Max, 128 GB**, macOS 26.5.1,
+oMLX **v0.4.4**, `mlx-lm` **0.31.3** installed via `uv tool`). Scripts in the
+session scratchpad (not committed). The on-disk model is
+`Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` (alias `coding-fast`, `is_pinned: true`).
+
+### Phase A — recommended Flavor-1 architecture (COMPLETE)
+
+| # | Test | oMLX v0.4.4 | mlx_lm.server 0.31.3 |
+|---|---|---|---|
+| A2/A3 | Tool-call round-trip (30B, full-attn MoE) | **PASS** — `finish_reason=tool_calls`, args `{"city":"Paris"}` | **PASS** — identical well-formed JSON |
+| A4 | 16-way concurrency (shared long prefix, 952 prompt-tok) | **16/16**, wall **4.57 s**, single-baseline 0.63 s (~2.2× batch) | **16/16**, wall **2.76 s**, single-baseline 1.01 s (~5.8× batch); logs show batched prefill at `--prompt-concurrency 8` |
+| A5 | Memory release on stop/kill | graceful `omlxctl stop` freed **30.3 GB** | SIGTERM freed **39.4 GB**, process gone |
+
+**Findings:**
+
+- **No concurrency crash on either engine.** The oMLX bugs #1970/#95 concern
+  *multi-model swap*, not single-model load — confirming the per-tier-process
+  design (one model per `mlx_lm.server`) sidesteps them entirely.
+- **mlx_lm.server matched/beat oMLX on the concurrent fan-out** (2.76 s vs 4.57 s
+  wall for 16), the exact property oMLX was originally chosen for. oMLX wins
+  single-stream latency (0.63 s vs 1.01 s). Single-run sample — directional.
+- **The exo #1370 "memory won't release on kill" risk did NOT reproduce** on this
+  M5 Max for either engine; both released ≥ the model footprint cleanly.
+- oMLX cold start to ready ≈ 2 s (model pinned/warm cache); mlx_lm.server load
+  ≈ 4 s from cold.
+
+**Phase A verdict:** the recommended architecture (per-tier `mlx_lm.server` behind
+a runtime-agnostic proxy, co-resident lineup, no swapping) is **validated** — tool
+fidelity, concurrent batching, and memory hygiene all hold, and mlx_lm.server is at
+least competitive with oMLX on the metric that drove the original choice.
+
+### Phase B — hybrid-attention tool-call claim (COMPLETE)
+
+Model: `lmstudio-community/Qwen3-Coder-Next-MLX-4bit` (42 GB on disk, 9 shards;
+verified `Qwen3NextForCausalLM`, **text-only**, 262K ctx — the genuine
+Gated-DeltaNet+Attention hybrid). Same `get_weather` tool-call round-trip.
+
+| Engine | Result | Detail |
+|---|---|---|
+| **oMLX v0.4.4** | **PASS ✓** | well-formed `{"city":"Paris"}`; first request 15.9 s incl. **live lazy auto-load** of the 45 GB model (confirms Part 1 auto-swap end-to-end) |
+| **mlx_lm.server 0.31.3** | **FAIL ✗ (3/3 deterministic)** | `finish_reason=tool_calls` but **empty `tool_calls`**; server log: `Failed to parse tool call (JSONDecodeError)` — its generic parser can't extract Qwen3-Coder's native (XML-ish `<tool_call>`) format; only 22 completion tokens, so not a length truncation |
+
+**Phase B verdict — the §2.7 claim is REFUTED, and the inverse is true:**
+
+- oMLX does **not** mishandle hybrid-attention tool-calls — it parsed Qwen3-Coder-Next
+  correctly (it ships Qwen-aware tool parsing).
+- **mlx_lm.server's tool-call parsing is model-format-dependent**: it handled
+  Qwen3-Coder-30B-A3B (Phase A) but **fails on Qwen3-Coder-Next**. This is a real
+  gap in the proposed replacement engine for the strongest local coder (70.6%
+  SWE-bench), reproduced 3/3.
+
+## Part 3 conclusion — recommendation REVISED by the empirics
+
+The Part 2 lean was "switch off oMLX to mlx_lm.server-per-tier." **The bake-off
+moves that back toward "stay on oMLX, configured to never swap."** Reasons, all
+empirically grounded:
+
+1. **oMLX's open bugs are all on the multi-model *swap/load* path** (#1970 lock
+   during load, #1938 cycling, #514 stacked-OOM, #1892 DFlash). **A co-resident,
+   pre-warmed, *pinned*, DFlash-off lineup never triggers them** — nothing loads
+   or evicts in steady state. Single-model 16-way concurrency ran 16/16 clean on
+   oMLX (and on mlx_lm.server).
+2. **oMLX has stronger, more uniform tool-call fidelity** — it parsed both
+   Qwen3-Coder variants; mlx_lm.server failed on Qwen3-Coder-Next (3/3). For
+   agentic coding, tool fidelity outranks the modest batch-throughput edge.
+3. **Memory hygiene is fine on this host** — both engines released cleanly on
+   stop/kill; the exo #1370 risk did not reproduce.
+4. The one place mlx_lm.server won — **16-way batch wall-time (2.76 s vs 4.57 s)** —
+   is real but secondary to tool fidelity, and is per-tier either way.
+
+### Recommended target architecture (post-bake-off)
+
+- **Keep oMLX as the engine.** Adopt the **all-co-resident, pinned, no-swap**
+  lineup so the multi-model bug surface is never exercised; disable DFlash SSD
+  cache (#702/#1892). Warm/pin every tier at startup.
+- **Lineup (Flavor 1, ~70 GB, fits with KV headroom):** T1 `coding-fast`
+  Qwen3-Coder-30B-A3B-8bit (current) · T2 GLM-4.7-Flash-8bit · T3
+  DeepSeek-Coder-V2-Lite-8bit. All `is_pinned: true`.
+- **If a stronger T3 is wanted (Qwen3-Coder-Next, 70.6% SWE-bench):** it does
+  **not** co-reside with T1+T2 plus KV headroom (~96 GB), so run it **on-demand**
+  (oMLX lazy-load, measured 15.9 s) with T1/T2 pinned. oMLX is the *only* engine
+  tested that serves its tool-calls correctly — a decisive point for this model.
+- **Router stays runtime-agnostic** regardless (the §2.4 lock-in point holds):
+  keep the .NET router pointed at one endpoint so the engine remains swappable if
+  oMLX's swap-path bugs ever block a future need.
+- **mlx_lm.server + llama-swap remains the documented fallback** if oMLX's
+  single-instance batching proves insufficient under real load — but only for
+  models whose tool format mlx_lm.server parses (verify per model).
+
+### Residual verifications before finalizing the lineup
+
+- **Tool-call fidelity of GLM-4.7-Flash and DeepSeek-Coder-V2-Lite** on the chosen
+  engine (not yet downloaded/tested) — mlx_lm.server's gap shows tool parsing is
+  per-model; oMLX likely fine but confirm.
+- **All-three-co-resident memory + KV headroom under real 16-way load** (we
+  measured single models; co-resident peak under concurrency is untested).
+- Whether to pursue Qwen3-Coder-Next as on-demand T3 (accepts cold-start + bounded
+  #1970 exposure) vs a co-resident-only lineup (no swap ever).
+
+## Part 4 — T3 ("quality") tier selection (COMPLETE)
+
+After the bake-off, the operator chose to keep GLM-4.7-Flash as T2 and **rethink
+T3** (Qwen3-Coder-Next can't co-reside — 45 GB — so it becomes a separate
+on-demand "max" tier, not T3). Three agents evaluated the best *co-resident* T3.
+
+### Structural finding
+
+**Every model that fits a 3-way co-resident budget on 128 GB is ~30B-class.** The
+genuine fidelity *leap* (70–80B: Qwen3-Coder-Next, Kimi-Dev-72B) only exists as an
+**on-demand** tier. So T3's value is not "bigger" — it must open a *non-redundant
+capability niche* vs the two MoEs already present:
+
+| | SWE-bench Verified | tool-seq (tau²) | IFEval | hallucination |
+|---|---|---|---|---|
+| T1 Qwen3-Coder-30B-A3B (MoE) | 51.6% | 49.0% | 88.9% | 21% |
+| T2 GLM-4.7-Flash (MoE) | 59.2% | 79.5% | — | 6% |
+
+T1 (instruction fidelity / long-context) and T2 (agentic SWE / tool sequencing)
+already span the two axes available at ~3B-active MoE class. A third MoE coder is
+**redundant**. The differentiator must be **architecture (dense) + objective
+(agentic-SWE fine-tune)**.
+
+### Two corrections from the memory agent (carry into ADR-006)
+
+- **KV starvation is not the constraint** at 3-agent scale: Qwen3-Coder-30B-A3B is
+  GQA, ~112 KB/token → 3 agents @ 8K ≈ 2.6 GB. Even with T3 resident, headroom
+  supports ~21 concurrent 8K agents. The real fence is the **96 GB Metal wired
+  ceiling** (`iogpu.wired_limit_mb=98304`) — above it, hard `MTLCommandBuffer`
+  failure, not slow degradation. So `T1+T2+T3+Next` (~116 GB) is *physically
+  impossible*, not merely slow.
+- **The "soft co-load Next alongside T1" path is a trap, not an affordance** — it
+  forces T2↔Next yo-yo eviction (oMLX #1938) and the 15.9 s load is I/O-bound
+  regardless. **Next is on-demand either way**, so T3's only real cost is its
+  ~14 GB weight budget. Earlier framing (T3 vs "Next ergonomics") was wrong.
+
+### Reasoning-tuned T3 is REJECTED (strong evidence)
+
+A thinking/reasoning model (QwQ-32B, GLM-Z1, R1-distill, Qwen3-32B thinking) is the
+**wrong** T3 for an agentic hot path. Deep research across vLLM/Ollama/LM Studio:
+Qwen3-32B thinking mode showed **~60% tool-call failure** (plans the call inside
+`<think>`, never emits it, sometimes *fabricates* it); `/no_think` is unreliable
+and placement-sensitive; the hard `enable_thinking=False` conflicts with reasoning
+parsers in some stacks; renderer bugs leave unclosed `</think>` corrupting
+multi-turn; Qwen3.5 dropped the soft switch entirely. Reasoning belongs (if at all)
+in the on-demand max tier, not a co-resident agentic tier.
+
+### T3 decision
+
+**Primary T3: `Devstral-Small-2507` (4-bit MLX).** Verified
+`MistralForCausalLM`, **text-only** (no `vision_config` — distinct from the
+multimodal Mistral-Small-3.2), 131K context; MLX builds
+`mlx-community/Devstral-Small-2507-4bit` (~13–14 GB) and `-8bit`, plus
+`lmstudio-community/Devstral-Small-2507-MLX-4bit`. Purpose-built **agentic SWE**
+(~68% SWE-bench Verified — ~9 pts over GLM-Flash), **dense 24B** (different
+decode/coherence profile from the two MoEs). It is the one ~30B-class model that
+opens a non-redundant niche. Route ~7–10 % of traffic (multi-file refactors,
+test-driven iteration, hardest single-shot) to it.
+
+**Alternate T3: `mlx-community/Qwen2.5-Coder-32B-Instruct-4bit`** (18.4 GB,
+`Qwen2ForCausalLM`, text-only verified, 128K). Use if Devstral's tool-call
+fidelity on oMLX disappoints, or if a pure-coder profile is preferred over
+agentic-SWE specialization.
+
+**If T3 were any other ~30B MoE coder → drop T3** (run T1+T2 + on-demand Next):
+redundant capability, and same-class routing collapses toward T1 without a trained
+complexity classifier.
+
+### Recommended final lineup (post-research, pending residual verification)
+
+| Tier | Model | Quant | ~Resident | Role / traffic |
+|---|---|---|---|---|
+| T1 fast | Qwen3-Coder-30B-A3B-Instruct-MLX-8bit (current) | 8-bit | 30.6 GB | general coding, tool chains (~55%) |
+| T2 medium | GLM-4.7-Flash | 8-bit | ~21 GB | fast tool relay / agentic (~30%) |
+| T3 quality | **Devstral-Small-2507** | 4-bit | ~14 GB | hardest agentic-SWE (~7–10%) |
+| — co-resident, all `is_pinned`, no swap | | | **~66 GB** | ~24–30 GB KV headroom |
+| Max (on-demand) | Qwen3-Coder-Next-MLX-4bit | 4-bit | 45 GB | architectural / very-long-context / hardest (~8%); oMLX-only tool fidelity; ~16 s cold start |
+
+### Agent Efficacy Report (Part 4)
+
+| Agent | Type | Key contribution | Value |
+|---|---|---|---|
+| Best co-resident T3 coder | general-purpose | Surfaced Qwen2.5-Coder-32B-4bit (dense, verified text-only) as the safe coder T3; disqualified DeepSeek-Lite (MoE, redundant) | High |
+| Is a 3rd tier worth it? | general-purpose | Reframed T3 as a capability (not memory) question; identified Devstral Small as the only non-redundant niche; corrected KV + Next-co-load errors | High (changed the answer) |
+| Reasoning-tuned T3 | general-purpose | Decisive evidence that thinking-mode breaks agentic tool-calling → reject reasoning T3 | High |
+
+**Disagreement:** coder agent → Qwen2.5-Coder-32B; worth-it agent → Devstral Small.
+**Resolved** by the orchestrator: Devstral verified text-only + MLX-available +
+higher agentic-SWE → **primary**; Qwen2.5-Coder-32B → **alternate**.
+**Reliability note:** the reasoning-tuned agent **spawned its own sub-agents**
+(a sub-agent-fan-out that violates the sub-agent obligation — orchestrator
+visibility lost); its findings were source-cited and retained, but the behavior is
+flagged. Several child searches hit transient API rate-limiting (high parallel
+load).
+**Custom-agent feedback:** no catalog agent covers local-LLM inference / MLX model
+selection — a recurring gap across this whole investigation; a `local-llm-expert`
+or `mlx-expert` agent would have replaced ~9 general-purpose invocations.
+
+## Part 5 — Residual verification on oMLX (COMPLETE) — the lineup changed
+
+Run 2026-06-23/24 on the M5 Max, oMLX v0.4.4. Downloaded GLM-4.7-Flash-8bit,
+Devstral-Small-2507-4bit, then Qwen2.5-Coder-32B-Instruct-4bit. **Verify-first paid
+off again — it overturned the Part 4 T3 pick.**
+
+### Tool-call fidelity on oMLX (the decisive gate)
+
+| Model | Role | Tool-call on oMLX | Note |
+|---|---|---|---|
+| Qwen3-Coder-30B-A3B-8bit | T1 | **PASS ✓** | (Phase A) |
+| GLM-4.7-Flash-8bit | T2 | **PASS ✓** | clean `{"city":"Paris"}` |
+| Qwen3-Coder-Next-4bit | Max (on-demand) | **PASS ✓** | (Phase B) |
+| **Devstral-Small-2507-4bit** | T3 cand. | **FAIL ✗** | emits no parseable call; *even `tool_choice=required` ignored* (Mistral protocol not wired in oMLX) |
+| **Qwen2.5-Coder-32B-4bit** | T3 cand. (alt) | **FAIL ✗** | emits the call but wraps it in `<tools>…</tools>` not `<tool_call>…</tool_call>` → oMLX parser drops it |
+
+**Conclusion: no co-resident dense ~30B T3 candidate has clean tool-calling on
+oMLX.** Both fail, for different reasons. Combined with the late reasoning-T3
+research (Qwen2.5-Coder is weak at *multi-turn agentic* editing — Aider-polyglot
+~8–16% — and Qwen3-32B/reasoning models carry their own tool-parser bugs +
+thinking-interference), there is **no compelling, tool-clean, co-resident dense
+T3** today.
+
+### Other measured facts
+
+- **GLM-4.7-Flash-8bit is ~30 GB on disk/resident, not the ~21 GB estimated** in
+  Parts 3–4. Corrects the co-resident budget.
+- **Co-resident T1+T2 under 16-way load: 16/16 PASS** (7.58 s wall). Memory released
+  cleanly on stop.
+- Model discovery requires an oMLX **restart** to pick up newly-downloaded dirs
+  (it scans at boot; a model added after start returns `not_found` until restart).
+
+### REVISED FINAL LINEUP (all tool-paths verified on oMLX)
+
+Drop the co-resident dense T3. Ship **2 co-resident + 1 on-demand = 3 tiers**:
+
+| Tier | Model | Quant | ~Resident | Tools on oMLX | Role |
+|---|---|---|---|---|---|
+| T1 fast | Qwen3-Coder-30B-A3B-Instruct-MLX-8bit *(current)* | 8-bit | 30.6 GB | ✓ | general coding (~55%) |
+| T2 medium | GLM-4.7-Flash-8bit | 8-bit | ~30 GB | ✓ | fast tool relay / agentic; best tool-seq (~30–35%) |
+| — co-resident, both `is_pinned`, no swap | | | **~61 GB** | | ~29 GB KV headroom |
+| Max (on-demand) | Qwen3-Coder-Next-MLX-4bit | 4-bit | 45 GB | ✓ | high-fidelity (70.6% SWE-bench); ~16 s lazy load (~10%) |
+
+This satisfies "3+ tiers, fidelity-by-workload" (fast → tool-relay → high-fidelity
+on demand), keeps every tool path verified-working, never swaps in steady state
+(so oMLX's multi-model bugs never fire), and leaves generous KV headroom. **Add a
+co-resident dense T3 later only when a ~30B model ships that is both strong at
+agentic editing AND tool-clean on oMLX** (re-open this section then).
+
+### Unused downloads
+
+`Devstral-Small-2507-4bit` (12 GB) and `Qwen2.5-Coder-32B-Instruct-4bit` (17 GB)
+were verification-only and are not in the final lineup — candidates for deletion
+from `~/models` (operator's call; not removed automatically).
+
+### Possible future unblock (not pursued)
+
+Qwen2.5-Coder-32B *can* emit correct tool JSON — only the wrapper tag differs.
+If oMLX exposes a per-model tool-parser override for the `<tools>` dialect, it
+could be revived; deemed not worth the per-model fragility vs the clean on-demand
+Next tier.
+
+## Part 6 — Would leaving oMLX unlock more capable models? (COMPLETE)
+
+Operator question: is the text-only constraint (which excludes the newest/biggest
+models via the VLM trap) an *oMLX* limitation that a runtime switch would lift,
+netting more capable models? Three agents + a direct issue-tracker check.
+
+### Finding A — the VLM trap IS oMLX-specific (switch is mechanically possible)
+
+oMLX #1800 (`cache_offset` scalar/array crash) routes any `vision_config` model to
+a VLM engine that crashes on concurrent requests. Other runtimes avoid it:
+
+- **llama.cpp / llama-server** — vision is a *separate* `mmproj` GGUF; load the text
+  GGUF *without* `--mmproj` (or `--language-model-only`) and the VLM path **cannot
+  execute**. Native continuous batching at `--parallel 16`. Doesn't use `mlx-vlm`
+  at all → immune to that whole bug class. Cost: **no M5 Neural Accelerators
+  (~1.5× slower prefill)**, sublinear batch scaling.
+- **vllm-mlx / vllm-metal** — routes on *image-token presence*, not arch flag;
+  benchmarked **4.3× at 16 concurrent (M4 Max 128 GB)**. Younger stack.
+- **mlx_lm.server** — no (no continuous batching). **LM Studio** — partial (~4 cap).
+
+### Finding B — the trapped models are NOT better coders (no capability prize)
+
+| Model (status) | SWE-bench Verified | vs our stack |
+|---|---|---|
+| Qwen3-Coder-Next-80B-A3B *(ours, on-demand)* | **70.6–71.3%** | — |
+| Qwen3-Coder-30B-A3B *(ours, T1)* | ~69.6% | — |
+| Gemma-3-27B *(trapped)* | ~29% LiveCodeBench (½ of ours) | **catastrophic downgrade** |
+| Mistral-Small-3.2-24B *(trapped)* | none published (general VLM) | worse; its coder sibling Devstral 68% still < ours |
+| Qwen3.6-35B-A3B *(trapped)* | 73.4% **on Alibaba's non-standard scaffold** | normalizes to ~within-noise of ours (same 3B-active arch); **not a real upgrade** |
+
+### Finding C — the real ceiling is the 128 GB hardware, not the trap
+
+The genuinely stronger coders are **size-gated**, which no runtime fixes:
+Devstral-2-123B (72.2%, borderline-impossible at useful ctx), Qwen3-Coder-480B
+(~276 GB), GLM-4.7-full 358B (73.8%), DeepSeek-V3 (~380 GB). The best coders that
+*fit* are **already text-only and usable** (Qwen3-Coder-Next is the ~71% ceiling).
+
+### Fix status of the crash (#1800), checked directly
+
+- Upstream root-cause fix **`mlx-vlm` PR #1354 is MERGED** (2026-06-12).
+- **oMLX has NOT adopted it** — #1800 still open (stale 2026-06-11), zero oMLX PRs
+  reference it; oMLX must bump its vendored `mlx-vlm`, not in flight.
+- The `mlx-vlm` continuous-batching VLM path has **more open crashes** (#1422 MRoPE,
+  updated 2026-06-24; #1378 token_context desync) — not a single clean fix.
+
+### VERDICT — stay on oMLX
+
+Switching runtimes is *possible* but buys **essentially no coding capability**: the
+trapped models aren't better coders, and the genuinely-stronger ones are size-gated.
+The only prize is quality-of-life (running Qwen3.6-35B-A3B text-only, ~within-noise
+of what we have), paid for with the **MLX/M5-NPU speed advantage** and re-verifying
+per-model tool-calling on a new engine. **The capability ceiling is the hardware,
+not oMLX.** Keep oMLX with the verified text-only lineup.
+
+**Revisit trigger (concrete):** re-evaluate multimodal models only if oMLX ships a
+release that bumps `mlx-vlm` past #1354 **and** the remaining batching bugs (#1422,
+#1378) close — then re-run the concurrency probe. Independently, **llama.cpp
+text-only** remains a fallback path that sidesteps the trap now, if a future need
+demands a specific multimodal-only model.
+
+### Flagged unverified conflict
+
+Agent #2 referenced a *text-only* "Qwen3.6-27B dense (72–77%)", contradicting the
+earlier config-verified finding that the whole Qwen3.6 family is multimodal
+(`Qwen3_5ForConditionalGeneration`, vision_config). Treated as **unverified**; not
+pursued (it normalizes to ~within-noise regardless, so not decision-relevant).
+Verify the actual `config.json` before ever relying on it.
+
+### Agent Efficacy Report (Part 6)
+
+| Agent | Type | Key contribution | Value |
+|---|---|---|---|
+| VLM-trap runtime-specificity | general-purpose | Proved trap is oMLX-specific; llama.cpp (no-mmproj) + vllm-mlx unlock text-only concurrency; mlx_lm.server/LM Studio insufficient | High |
+| Trapped-models-better-coders | general-purpose | Quantified that trapped models are worse/equal coders (Gemma-3 ~29% LCB; Qwen3.6 scaffold-inflated) | High |
+| Trap-gated vs size-gated | general-purpose | Bucketed the field; showed best coders are already-usable or size-gated → ceiling is hardware | High |
+| (direct issue-tracker check) | orchestrator | #1800 open/unadopted; #1354 merged upstream; #1422/#1378 still open | High |
+
+**Disagreement:** none material — all three converged on "stay." Minor: agent #2's
+unverified text-only-Qwen3.6-27B claim (flagged above). **No sub-agent fan-out this
+round** (instructed against it; the earlier protocol drift did not recur).
+
+## Open decisions (to be resolved into ADR-006)
+
+- **Runtime:** keep oMLX (with guardrails) / switch / hedge with a
+  runtime-agnostic router. → Part 2.
+- **Tier topology:** all-co-resident (no swap) vs co-resident hot + lazy-load
+  large vs hybrid local + remote top tier.
+- **Top-tier quality ceiling:** strong MoE (co-resident) vs genuine large dense
+  (swap/remote).
+- **Model lineup + exact HF repo IDs + quants** (re-verify availability per
+  CLAUDE.md before any download).
+
+## Sources
+
+- oMLX: `github.com/jundot/omlx` (README, `engine_pool.py`, `server.py`,
+  `model_settings.py`, `model_registry.py`, issues #1970/#1938/#514/#702/#1892/#1800),
+  `omlx.ai`.
+- MLX on M5 / load + memory figures: Apple ML Research (Exploring LLMs with MLX on
+  M5), ThinkSmart.Life MLX guide, llmcheck.net Apple-Silicon benchmarks.
+- Prior decision context: [ADR-001](../adrs/001-local-mlx-inference-omlx.md) →
+  [ADR-004](../adrs/004-single-text-only-model-no-override.md),
+  [ADR-005](../adrs/005-on-demand-service-lifecycle.md),
+  [docs/router-wiring.md](router-wiring.md).

--- a/macos/local-llm-mac-os-creation.md
+++ b/macos/local-llm-mac-os-creation.md
@@ -23,20 +23,22 @@ The implementing agent follows its standard operating framework: classify the ta
 These came out of prior analysis. Treat the runtime and serving config as decided; **re-verify the model choice and exact HuggingFace MLX repo IDs against current availability** as of today before downloading anything — search, confirm the repo exists, and confirm it still represents the best local coding model for this hardware. If something better has shipped, propose it in the plan rather than silently substituting.
 
 - **Runtime:** oMLX, installed via Homebrew (`brew tap jundot/omlx https://github.com/jundot/omlx && brew install omlx`).
-- **Primary model:** a **Qwen3.6-35B-A3B at 8-bit** MLX build (`mlx-community/Qwen3.6-35B-A3B-8bit`; MoE, ~3B active → fast decode under the 614 GB/s bandwidth cap; 8-bit preserves tool-call JSON fidelity). ~38 GB resident. Alias `coding-fast`. **Requires `model_type_override = llm`** — the checkpoint carries a `vision_config` and oMLX's VLM engine crashes under concurrent requests (oMLX #1800; ADR-003). The setup script applies the override via the admin API.
-- **Secondary (optional):** a **Qwen3-Coder-30B-A3B-Instruct at 8-bit** MLX build (`lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit`, ~30 GB, verified text-only → concurrency-safe with no override). Alias `coding-quality`; the guaranteed-safe fan-out fallback.
+- **Model tiers (ADR-006):** three verified text-only coder builds (no `vision_config` → batched LLM engine, no override), tool-call-verified on oMLX:
+  - **T1 `coding-fast`** — `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` (`Qwen3MoeForCausalLM`, MoE ~3B active, 262K ctx), ~30.6 GB. **Pinned, co-resident.**
+  - **T2 `coding-balanced`** — `mlx-community/GLM-4.7-Flash-8bit` (`Glm4MoeLiteForCausalLM`, MoE ~3B active, 202K ctx), ~30 GB. **Pinned, co-resident.**
+  - **MAX `coding-quality`** — `lmstudio-community/Qwen3-Coder-Next-MLX-4bit` (`Qwen3NextForCausalLM`, 80B/~3B active, ~71% SWE-bench), ~45 GB. **On-demand** (lazy-loads ~16 s on first request, idle-evicts; not pinned — it does not co-reside with T1+T2). The earlier multimodal Qwen3.6 primary + `model_type_override` approach (ADR-003) was retired: every Qwen3.6 build is VLM-trapped and no runtime change unlocks a better *coder* (ADR-006, `docs/runtime-tiering-research.md`).
 - **Serving flags:** `--host 127.0.0.1` (explicit loopback pin), port `8000`, `--memory-guard-gb 90` (replaces the removed `--max-process-memory`), `--paged-ssd-cache-dir ~/.omlx/cache`, `--hot-cache-max-size 18GB` (absolute size only — oMLX rejects percentages), `--max-concurrent-requests 16`, `--api-key` from the 0600 file.
-- **Metal wired limit:** raise `iogpu.wired_limit_mb` to ~96 GB (98304) so Metal can wire both models with KV headroom; persist across reboot via a LaunchDaemon (needs sudo).
+- **Metal wired limit:** raise `iogpu.wired_limit_mb` to ~96 GB (98304) so Metal can wire the two co-resident tiers (~60 GB) with KV headroom; persist across reboot via a LaunchDaemon (needs sudo).
 - **On-demand lifecycle (no login autostart):** per-user LaunchAgent running a start wrapper (brew services only starts with zero-config defaults, so use a wrapper that carries the tuned flags). The agent is `RunAtLoad=false` + `KeepAlive=false` — registered at login but never started, and a stop/crash stays down. Start/stop is intentional via the installed `omlxctl` tool (ADR-005).
 
 ## What to do
 
-1. **Verify environment** — macOS, arm64, RAM ≥ ~120 GB, free disk ≥ ~100 GB, Homebrew present. Abort with exit 2 on those hard precondition failures. Treat M5 Max as the tuned target; warn rather than hard-fail on non-M5 Apple Silicon so nearby Max-class hosts can smoke-test deliberately.
+1. **Verify environment** — macOS, arm64, RAM ≥ ~120 GB, free disk ≥ ~140 GB (three tiers ≈ 105 GB + cache), Homebrew present. Abort with exit 2 on those hard precondition failures. Treat M5 Max as the tuned target; warn rather than hard-fail on non-M5 Apple Silicon so nearby Max-class hosts can smoke-test deliberately.
 2. **Author or reuse the setup script.** If `setup-omlx-m5.sh` already exists in the working directory, review it against the spec above and the conventions, then use it. Otherwise write it. It must: install oMLX (no MCP extra); create `~/models`, `~/.omlx/cache`, `~/.omlx/logs`; generate the 0600 API key; set + persist the wired limit; write the start wrapper; install the on-demand LaunchAgent (RunAtLoad=false) and the `omlxctl` control tool, leaving the server stopped; leave model download opt-in (default off) routing to the `/admin` downloader unless repo IDs are verified.
 3. **Lint it.** Run `shellcheck` and fix all Error/Warning findings; report results in the structured review format with a verdict line.
 4. **Run it**, supplying sudo when prompted for the wired-limit step.
-5. **Acquire the model(s).** Once you've verified the exact repo ID, download the primary model into `~/models` (via `hf download` or the `/admin` downloader). Confirm it loads.
-6. **Pin + alias** the primary model in the `/admin` panel (alias `coding-fast`) — pinning is panel-only, not a CLI flag, so do it via the API/UI or document the exact manual step for the operator if it can't be scripted.
+5. **Acquire the models.** Once you've verified the exact repo IDs, download the three tiers into `~/models` (via `hf download`), skipping any already present. Confirm they load.
+6. **Pin + alias the tiers** via the oMLX admin API (`apply_pins`: briefly start the server, PUT each tier's `model_alias`/`is_pinned` — T1+T2 pinned, MAX on-demand — then stop it; `model_settings.json` is oMLX-owned so never write it directly). Degrade to printed manual `/admin` steps if the API can't be reached.
 7. **Validate the endpoint** — `curl` `http://localhost:8000/v1/models` with the API key, then a small `/v1/chat/completions` call, and a **tool-calling** call to confirm the model emits well-formed `tool_call` markup (the orchestrator depends on this; flag if the parser needs configuration).
 
 ## Deliverables
@@ -44,7 +46,7 @@ These came out of prior analysis. Treat the runtime and serving config as decide
 - A working, pinned oMLX server reachable at `http://localhost:8000/v1` (and `/v1/messages` for Anthropic-style clients).
 - The reviewed, shellcheck-clean setup script.
 - An **ADR** (MADR minimal, in `adrs/`) recording the local-inference convention: runtime choice, model choice with the bandwidth/MoE rationale, and the serving config.
-- A note on wiring the downstream `IInferenceBackend` / `FallbackInferenceRouter` endpoint to this server (route `coding-fast` → primary; `coding-quality` → secondary if installed).
+- A note on wiring the downstream `IInferenceBackend` / `FallbackInferenceRouter` endpoint to this server (route `coding-fast`/`coding-balanced` → co-resident tiers; `coding-quality` → on-demand max tier, remote as fallback).
 - An efficacy report.
 
 Stop and show the operator the plan before executing anything that writes, installs, or runs.

--- a/setup-omlx-m5.sh
+++ b/setup-omlx-m5.sh
@@ -12,7 +12,9 @@
 #   ./setup-omlx-m5.sh [options]
 #
 # Options:
-#   --download-model   Download the model (~32 GB) via `hf download`. Off by default.
+#   --download-model   Download the three model tiers (~105 GB total) via
+#                      `hf download`. Off by default. Existing models are skipped,
+#                      so this is safe to re-run when upgrading.
 #   --configure-pi     Register the oMLX provider with the Pi coding agent.
 #                      Auto-writes ~/.pi/agent/models.json ONLY when its
 #                      providers object is empty (backup taken first);
@@ -76,17 +78,35 @@ WIRED_LIMIT_MB=98304    # 96 GB; leaves ~32 GB for macOS on a 128 GB host (ADR-0
 WIRED_MIN_MB=90000      # wrapper warns below this
 
 MIN_RAM_GB=120
-MIN_DISK_GB=100         # ~32 GB model plus paged-SSD cache headroom (ADR-004)
+MIN_DISK_GB=140         # T1+T2 (~60 GB) + on-demand MAX (~45 GB) + paged-SSD cache headroom (ADR-006)
 
-# Repo ID verified against the HuggingFace config.json on 2026-06-22 (ADR-004).
-# Re-probed before every download, but still confirm the best current model before
-# large downloads. The model is a verified text-only coder build
-# (Qwen3MoeForCausalLM, no vision_config) → it routes to oMLX's batched LLM engine
-# and is concurrency-safe with NO engine override. A single resident model keeps
-# the whole KV/prefix-cache budget under the wired ceiling for the fan-out.
-PRIMARY_REPO="lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit"
-PRIMARY_DIR="$MODELS_DIR/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit"
+# --- Model tiers (ADR-006) --------------------------------------------------
+# Three tiers, all verified TEXT-ONLY MLX coder builds (no vision_config → batched
+# LLM engine, concurrency-safe, no engine override) and tool-call-verified on oMLX:
+#   T1  coding-fast     Qwen3-Coder-30B-A3B-8bit   (~30.6 GB)  PINNED, co-resident
+#   T2  coding-balanced GLM-4.7-Flash-8bit         (~30 GB)    PINNED, co-resident
+#   MAX coding-quality  Qwen3-Coder-Next-4bit      (~45 GB)    on-demand (lazy-load, NOT pinned)
+# T1+T2 stay co-resident under the 96 GB wired ceiling with KV headroom; MAX is
+# lazy-loaded on first request and TTL-evicts when idle (never co-resident — it
+# does not fit alongside T1+T2). Repo IDs verified against HuggingFace config.json
+# on 2026-06-24; re-probed before each download. Confirm the best current models
+# before large downloads. See docs/runtime-tiering-research.md.
+#
+# Each TIER_MODELS entry is "repo|alias|pinned(true|false)" — order is T1, T2, MAX.
+# Bash-3.2-safe indexed array (macOS default shell).
+TIER_MODELS=(
+    "lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit|coding-fast|true"
+    "mlx-community/GLM-4.7-Flash-8bit|coding-balanced|true"
+    "lmstudio-community/Qwen3-Coder-Next-MLX-4bit|coding-quality|false"
+)
+# T1's alias drives the detailed validation probes below (chat/tool/concurrency).
 PRIMARY_ALIAS="coding-fast"
+
+# Field accessors for a TIER_MODELS entry (split on '|').
+tier_repo()  { printf '%s' "${1%%|*}"; }
+tier_alias() { local r="${1#*|}"; printf '%s' "${r%%|*}"; }
+tier_pin()   { printf '%s' "${1##*|}"; }
+tier_dir()   { printf '%s' "$MODELS_DIR/$(basename "$(tier_repo "$1")")"; }
 
 # Pi coding-agent provider registration (--configure-pi). contextWindow is half
 # the model's 262144-token native context (verified config.json, rope_scaling
@@ -566,7 +586,13 @@ maybe_download_models() {
         skip "model" "download is opt-in — re-run with --download-model, or use the /admin downloader (verify the exact quant tags first)"
         return
     fi
-    download_model "$PRIMARY_REPO" "$PRIMARY_DIR" "model"
+    # All three ADR-006 tiers. download_model() skips any dir that is already
+    # populated, so on an upgrade from a single-model (ADR-004) install only the
+    # missing tiers are fetched.
+    local entry
+    for entry in "${TIER_MODELS[@]}"; do
+        download_model "$(tier_repo "$entry")" "$(tier_dir "$entry")" "model-$(tier_alias "$entry")"
+    done
 }
 
 # --- Step: Pi coding-agent provider registration (--configure-pi) -----------
@@ -576,11 +602,14 @@ maybe_download_models() {
 # parse shows an empty providers object (backup taken first; git covers the
 # rest). Anything else gets the rendered snippet plus manual merge steps.
 print_pi_settings_instructions() {
-    local settings_file="$1" primary_id="$2"
+    local settings_file="$1"
     # settings.json is hand-curated and git-tracked; never edited automatically.
-    info "To surface the model in Pi's picker, add to the enabledModels array in $settings_file:"
-    echo "      \"omlx/${primary_id}\""
-    echo "      Select with: pi --model omlx/${primary_id}  (or /model in a session — models.json reloads on /model)"
+    info "To surface the tiers in Pi's picker, add to the enabledModels array in $settings_file:"
+    local entry
+    for entry in "${TIER_MODELS[@]}"; do
+        echo "      \"omlx/$(tier_alias "$entry")\""
+    done
+    echo "      Select with: pi --model omlx/$(tier_alias "${TIER_MODELS[0]}")  (or /model in a session — models.json reloads on /model)"
 }
 
 configure_pi_provider() {
@@ -598,13 +627,18 @@ configure_pi_provider() {
     local models_file="$PI_AGENT_DIR/models.json"
     local settings_file="$PI_AGENT_DIR/settings.json"
     local snippet_dest="$OMLX_HOME/pi-provider-snippet.json"
-    local primary_id
-    primary_id="$(basename "$PRIMARY_DIR")"
+    # Register the tiers by their oMLX aliases (ADR-006).
+    local t1_id t2_id max_id
+    t1_id="$(tier_alias "${TIER_MODELS[0]}")"
+    t2_id="$(tier_alias "${TIER_MODELS[1]}")"
+    max_id="$(tier_alias "${TIER_MODELS[2]}")"
 
     if render_template "$TEMPLATE_DIR/pi-models-omlx.json" "$snippet_dest" \
         "__PORT__"              "$PORT" \
         "__API_KEY_FILE__"      "$API_KEY_FILE" \
-        "__PRIMARY_ID__"        "$primary_id" \
+        "__T1_ID__"             "$t1_id" \
+        "__T2_ID__"             "$t2_id" \
+        "__MAX_ID__"            "$max_id" \
         "__PI_CONTEXT_WINDOW__" "$PI_CONTEXT_WINDOW" \
         "__PI_MAX_TOKENS__"     "$PI_MAX_TOKENS"; then
         ok "pi-config" "rendered provider snippet: $snippet_dest"
@@ -618,7 +652,7 @@ configure_pi_provider() {
     # Idempotency: never rewrite a models.json that already names this provider.
     if [ -f "$models_file" ] && grep -q '"omlx"' "$models_file"; then
         skip "pi-config" "\"omlx\" provider already present in $models_file (left untouched)"
-        print_pi_settings_instructions "$settings_file" "$primary_id"
+        print_pi_settings_instructions "$settings_file"
         return
     fi
 
@@ -658,18 +692,147 @@ PYEOF
         info "Insert the \"omlx\" block from $snippet_dest into the providers object of $models_file"
     fi
 
-    print_pi_settings_instructions "$settings_file" "$primary_id"
+    print_pi_settings_instructions "$settings_file"
 }
 
-# --- Pin/alias instructions (GUI-only; cannot be scripted) ------------------
+# --- Pin/alias fallback instructions (when the admin API can't be reached) --
 print_pin_instructions() {
-    # Printed unconditionally (not via detail/--verbose): pinning is GUI-only and
-    # cannot be scripted, so these are required manual steps, not optional detail.
-    info "Model pin + alias is admin-panel only (not a CLI flag). Manual steps:"
+    # Printed when apply_pins cannot reach the admin API. Lists every tier so the
+    # operator can set aliases + pins manually in the admin panel.
+    info "Apply model aliases + pins manually in the admin panel:"
     echo "      1. Start the server (omlxctl start), then open http://localhost:${PORT}/admin"
-    echo "      2. Under Models, set the alias for $(basename "$PRIMARY_DIR") to '${PRIMARY_ALIAS}' and PIN it (keeps it resident)."
-    echo "      The alias persists in ${OMLX_HOME}/settings.json and appears in GET /v1/models."
-    echo "      No engine override is needed — the model is text-only (Qwen3MoeForCausalLM); ADR-004."
+    echo "      2. Under Models, for each tier set the alias and pin state:"
+    local entry
+    for entry in "${TIER_MODELS[@]}"; do
+        if [ "$(tier_pin "$entry")" = "true" ]; then
+            echo "         - $(basename "$(tier_repo "$entry")")  alias '$(tier_alias "$entry")'  PIN (keep co-resident)"
+        else
+            echo "         - $(basename "$(tier_repo "$entry")")  alias '$(tier_alias "$entry")'  do NOT pin (on-demand; set idle TTL if desired)"
+        fi
+    done
+    echo "      Aliases/pins persist in ${OMLX_HOME}/model_settings.json and appear in GET /v1/models."
+    echo "      No engine override is needed — all tiers are text-only coder builds (ADR-006)."
+}
+
+# Idempotency gate: returns 0 if model_settings.json already has every tier's
+# alias and pin state. We only READ the oMLX-owned file here. Lets a re-run skip
+# the whole start/pin/stop cycle (no server churn) — key for upgrade re-runs.
+pins_already_applied() {
+    [ -f "$OMLX_HOME/model_settings.json" ] || return 1
+    python3 - "$OMLX_HOME/model_settings.json" "${TIER_MODELS[@]}" <<'PYEOF' 2>/dev/null
+import json, os, sys
+try:
+    models = json.load(open(sys.argv[1])).get("models", {})
+except Exception:
+    sys.exit(1)
+for t in sys.argv[2:]:
+    repo, alias, pin = t.split("|")
+    m = models.get(os.path.basename(repo))
+    if not m or m.get("model_alias") != alias or bool(m.get("is_pinned")) != (pin == "true"):
+        sys.exit(1)
+sys.exit(0)
+PYEOF
+}
+
+# --- Pin/alias via the oMLX admin API (ADR-006) -----------------------------
+# Sets each tier's alias + pin state by briefly starting the server, PUTting the
+# per-model settings, then stopping it — so ADR-005's end-state invariant (server
+# stopped after setup, no login autostart) is preserved. model_settings.json is
+# oMLX-owned, so we go through the admin API rather than writing the file. The
+# admin mount prefix is probed (it has drifted between /admin/api and /api). The
+# whole step degrades to print_pin_instructions + a warning — never a hard failure.
+apply_pins() {
+    if ! $OMLX_PRESENT; then
+        record_warn "pin" "omlx not installed — skipping admin pinning; re-run after installing omlx"
+        print_pin_instructions; return
+    fi
+    if [ ! -r "$API_KEY_FILE" ]; then
+        record_warn "pin" "API key not readable — skipping admin pinning"
+        print_pin_instructions; return
+    fi
+    local any_present=false entry
+    for entry in "${TIER_MODELS[@]}"; do
+        if [ -d "$(tier_dir "$entry")" ] && [ -n "$(ls -A "$(tier_dir "$entry")" 2>/dev/null)" ]; then any_present=true; fi
+    done
+    if ! $any_present; then
+        skip "pin" "no tier models on disk yet — download them (--download-model), then re-run to apply pins"
+        print_pin_instructions; return
+    fi
+    if pins_already_applied; then
+        skip "pin" "all tier aliases + pins already set in model_settings.json (no server start needed)"
+        return
+    fi
+
+    local key base auth
+    key="$(cat "$API_KEY_FILE")"
+    base="http://localhost:${PORT}"
+    auth="Authorization: Bearer ${key}"
+
+    # Only stop the server afterwards if WE started it (respect an already-running server).
+    local started_by_us=false
+    if ! curl -fsS --max-time 3 -H "$auth" "${base}/health" >/dev/null 2>&1; then
+        info "Briefly starting the server to apply pins (will stop it afterwards)"
+        if [ -x "$CONTROL_PATH" ] && "$CONTROL_PATH" start >/dev/null 2>&1; then
+            started_by_us=true
+        else
+            record_warn "pin" "could not start the server to apply pins (omlxctl start failed)"
+            print_pin_instructions; return
+        fi
+    fi
+
+    local ready=false
+    for _ in $(seq 1 60); do
+        if curl -fsS --max-time 3 -H "$auth" "${base}/health" >/dev/null 2>&1; then ready=true; break; fi
+        sleep 2
+    done
+    if ! $ready; then
+        record_warn "pin" "server did not become ready — skipping admin pinning"
+        $started_by_us && "$CONTROL_PATH" stop >/dev/null 2>&1 || true
+        print_pin_instructions; return
+    fi
+
+    # Probe the admin mount prefix.
+    local admin="" p
+    for p in "/admin/api" "/api"; do
+        if curl -fsS --max-time 5 -H "$auth" "${base}${p}/models" >/dev/null 2>&1; then admin="$p"; break; fi
+    done
+    if [ -z "$admin" ]; then
+        record_warn "pin" "admin API not found at /admin/api or /api — apply pins manually"
+        $started_by_us && "$CONTROL_PATH" stop >/dev/null 2>&1 || true
+        print_pin_instructions; return
+    fi
+    detail "admin API mounted at ${admin}"
+
+    local mid alias pin body
+    for entry in "${TIER_MODELS[@]}"; do
+        mid="$(basename "$(tier_repo "$entry")")"
+        alias="$(tier_alias "$entry")"
+        pin="$(tier_pin "$entry")"
+        if [ ! -d "$(tier_dir "$entry")" ]; then skip "pin-${alias}" "model ${mid} not on disk — skipping"; continue; fi
+        # PINNED tiers (T1/T2): co-resident, DFlash off. MAX tier: not pinned,
+        # idle-evict after 15 min, DFlash off (oMLX #702/#1892).
+        if [ "$pin" = "true" ]; then
+            body="{\"model_alias\":\"${alias}\",\"is_pinned\":true,\"dflash_ssd_cache\":false}"
+        else
+            body="{\"model_alias\":\"${alias}\",\"is_pinned\":false,\"ttl_seconds\":900,\"dflash_ssd_cache\":false}"
+        fi
+        if curl -fsS --max-time 20 -X PUT -H "$auth" -H 'Content-Type: application/json' \
+            -d "$body" "${base}${admin}/models/${mid}/settings" >/dev/null 2>&1; then
+            ok "pin-${alias}" "alias '${alias}' (pinned=${pin}) set for ${mid}"
+        else
+            record_warn "pin-${alias}" "admin PUT failed for ${mid} — set alias/pin manually at ${base}/admin"
+        fi
+    done
+
+    if $started_by_us; then
+        if "$CONTROL_PATH" stop >/dev/null 2>&1; then
+            ok "pin" "pins applied; server stopped (on-demand end-state restored)"
+        else
+            record_warn "pin" "pins applied but failed to stop the server — run: omlxctl stop"
+        fi
+    else
+        ok "pin" "pins applied against the already-running server (left running)"
+    fi
 }
 
 # --- Validation -------------------------------------------------------------
@@ -687,11 +850,17 @@ validate_endpoint() {
     if models="$(curl -fsS -H "$auth" "${base}/models" 2>/dev/null)"; then
         ok "validate-models" "GET /v1/models reachable"
         detail "$models"
-        if echo "$models" | grep -q "$PRIMARY_ALIAS"; then
-            ok "validate-alias" "alias '${PRIMARY_ALIAS}' present"
-        else
-            record_warn "validate-alias" "alias '${PRIMARY_ALIAS}' not found — pin it in /admin"
-        fi
+        # Every tier alias should be registered. The MAX tier (coding-quality) is
+        # on-demand: it is listed once discovered, but only loads on first request.
+        local entry valias
+        for entry in "${TIER_MODELS[@]}"; do
+            valias="$(tier_alias "$entry")"
+            if echo "$models" | grep -q "$valias"; then
+                ok "validate-alias" "alias '${valias}' present"
+            else
+                record_warn "validate-alias" "alias '${valias}' not found — apply pins (re-run setup) or set it in /admin"
+            fi
+        done
     else
         record_err "validate-models" "GET /v1/models failed — is the server running? (launchctl print gui/$(id -u)/${AGENT_LABEL})"
         return
@@ -782,7 +951,7 @@ main() {
     else
         skip "pi-config" "Pi provider registration is opt-in — re-run with --configure-pi"
     fi
-    print_pin_instructions
+    apply_pins
 
     info "The server is installed but NOT running (startup is intentional)."
     info "Start it on demand:  omlxctl start    (stop: omlxctl stop, status: omlxctl status)"

--- a/templates/pi-models-omlx.json
+++ b/templates/pi-models-omlx.json
@@ -12,13 +12,16 @@
 //   supportsReasoningEffort: false  — reasoning_effort is not implemented
 //   supportsUsageInStreaming: false — streaming usage stats not guaranteed
 //
-// Model ids are the canonical oMLX model directory names (NOT the /admin
-// aliases) — see ADR-004; switch to aliases only after validating the alias
-// round-trip on the installed oMLX version.
+// Three tiers (ADR-006), addressed by their oMLX ALIASES (verified to resolve on
+// the installed version):
+//   coding-fast      T1  Qwen3-Coder-30B-A3B-8bit   pinned, co-resident
+//   coding-balanced  T2  GLM-4.7-Flash-8bit          pinned, co-resident
+//   coding-quality   MAX Qwen3-Coder-Next-4bit       on-demand (lazy-loads ~16 s on
+//                                                     first request, idle-evicts)
 //
-// contextWindow is held to 131072 (half the model's 262144-token native
-// context): 16 concurrent sessions at full context would overrun the KV/wired
-// budget and collapse prefix-cache reuse.
+// contextWindow is held to 131072 (≈ half the models' native context): 16
+// concurrent sessions at full context would overrun the KV/wired budget and
+// collapse prefix-cache reuse.
 {
   "providers": {
     "omlx": {
@@ -33,8 +36,26 @@
       },
       "models": [
         {
-          "id": "__PRIMARY_ID__",
-          "name": "coding-fast (local oMLX)",
+          "id": "__T1_ID__",
+          "name": "coding-fast — Qwen3-Coder-30B-A3B (local oMLX)",
+          "reasoning": false,
+          "input": ["text"],
+          "contextWindow": __PI_CONTEXT_WINDOW__,
+          "maxTokens": __PI_MAX_TOKENS__,
+          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+        },
+        {
+          "id": "__T2_ID__",
+          "name": "coding-balanced — GLM-4.7-Flash (local oMLX)",
+          "reasoning": false,
+          "input": ["text"],
+          "contextWindow": __PI_CONTEXT_WINDOW__,
+          "maxTokens": __PI_MAX_TOKENS__,
+          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+        },
+        {
+          "id": "__MAX_ID__",
+          "name": "coding-quality — Qwen3-Coder-Next (local oMLX, on-demand)",
           "reasoning": false,
           "input": ["text"],
           "contextWindow": __PI_CONTEXT_WINDOW__,


### PR DESCRIPTION
## Summary

Restores a multi-tier local model lineup, superseding ADR-004's single text-only model. The goal is fidelity-that-scales-with-workload with **zero manual model switching**, while keeping every tool-call path verified-working on oMLX.

The lineup is **two co-resident pinned tiers + one on-demand max tier** (= 3 tiers):

| Tier | Alias | Model | ~Resident | Residency |
|---|---|---|---|---|
| fast | `coding-fast` | Qwen3-Coder-30B-A3B-8bit | ~30.6 GB | pinned, co-resident |
| balanced | `coding-balanced` | GLM-4.7-Flash-8bit | ~30 GB | pinned, co-resident |
| quality | `coding-quality` | Qwen3-Coder-Next-4bit | ~45 GB | on-demand (lazy-load ~16 s, idle-evict) |

**Why stay on oMLX:** a runtime reassessment + on-host bake-off (M5 Max) showed the capability ceiling is the **128 GB hardware, not the runtime** — the VLM-trapped models aren't better coders and the genuinely stronger coders are size-gated. Keeping T1+T2 pinned/co-resident and never swapping in steady state means oMLX's open multi-model swap-path bugs never fire. Full rationale + bake-off results: `docs/runtime-tiering-research.md`; decision: `adrs/006-…md`.

**Migration-aware:** re-running `setup-omlx-m5.sh` is a non-destructive in-place upgrade from an ADR-004 install — it detects the existing model + pin, downloads only the missing tiers, merges pins via the admin API (never writing the oMLX-owned `model_settings.json`), preserves the API key / non-empty Pi config, and no-ops on a second run.

## Type of Change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change

## Test Plan

- `shellcheck setup-omlx-m5.sh` — clean (default + `-S style`); `bash -n` parses clean.
- `markdownlint` — the introduced findings (1 trailing space, 3 missing blank-line-before-list in the research doc) fixed and re-verified clean; remaining output is pre-existing repo-wide style noise (MD013/MD060) + an MD018 false-positive on `#1378`.
- **On-host bake-off (M5 Max, oMLX v0.4.4):** tool-call round-trips verified on oMLX for all three lineup models (`coding-fast`, `coding-balanced`, `coding-quality`); T1+T2 co-resident 16-way concurrency 16/16; on-demand lazy-load of Qwen3-Coder-Next confirmed (~16 s); memory released cleanly on stop/kill.
- **To run on the host after merge:** `omlxctl start` then `./setup-omlx-m5.sh --validate` to exercise `apply_pins` (admin-API start→pin→stop) and all three aliases end-to-end.

## Documentation Impact (per documentation-in-plan)

| Surface | Classification | Status |
|---|---|---|
| `adrs/006-…md` (new) + ADR-004 → superseded | in-scope | done |
| `setup-omlx-m5.sh`, `templates/pi-models-omlx.json` | in-scope | done |
| `README.md` (Model tiers, TL;DR, disk, teardown, upgrade section, repo-map row) | in-scope | done |
| `CLAUDE.md` (decision pointer, settled-decisions, pinning, layout, router note, teardown) | in-scope | done |
| `docs/router-wiring.md` (3-role alias map, on-demand `coding-quality`) | in-scope | done |
| `macos/local-llm-mac-os-creation.md` (was 2 ADRs stale → current) | in-scope | done |
| `docs/runtime-tiering-research.md` (new — decision rationale + bake-off) | in-scope | done |
| `model_settings.json` template | not-a-thing | admin-API pinning chosen → script never writes the oMLX-owned file |
| `.markdownlint-cli2.yaml` to silence repo-wide MD013/MD060 | out-of-scope | repo-wide convention change; can be filed separately |

## Checklist

- [x] No secrets/credentials committed (API key stays at `~/.omlx/api-key`, 0600, never tracked).
- [x] Models are verified text-only (no `vision_config`) — VLM-trap screened.
- [x] Tool-call fidelity verified on oMLX for every lineup model.
- [x] Idempotent / upgrade-safe (re-run is a no-op; existing state preserved).
- [x] `shellcheck` clean; ADR-005 stopped end-state preserved by `apply_pins`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
