### PR TITLE
feat: warn when omlx server runs with zero models loaded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ it). Start/stop it intentionally with the installed `omlxctl` tool (ADR-005):
 
 ```bash
 omlxctl start    # kickstart + wait for /health  |  omlxctl stop    # SIGTERM→SIGKILL(30s), release memory
-omlxctl restart  # atomic restart + wait         |  omlxctl status  # launchd + /health state  |  omlxctl logs
+omlxctl restart  # atomic restart + wait         |  omlxctl status  # launchd + /health state (warns on 0 models) |  omlxctl logs
 ```
 
 Exit codes: `0` pass, `1` errors, `2` precondition failure. Lint with the

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Startup is intentional — nothing wires the ~32 GB model until you ask. Control
 omlxctl start     # kickstart the server, then wait for /health (cold start ~90 s)
 omlxctl stop      # SIGTERM, flush hot cache to SSD, then SIGKILL after 30 s — releases memory
 omlxctl restart   # atomic restart, then wait for ready
-omlxctl status    # launchd registration/run state + /health readiness
+omlxctl status    # launchd registration/run state + /health readiness (warns if 0 models loaded)
 omlxctl logs      # recent stdout/stderr (live: tail -f ~/.omlx/logs/launchagent.*.log)
 ```
 

--- a/setup-omlx-m5.sh
+++ b/setup-omlx-m5.sh
@@ -583,7 +583,18 @@ download_model() {
 
 maybe_download_models() {
     if ! $DO_DOWNLOAD; then
-        skip "model" "download is opt-in — re-run with --download-model, or use the /admin downloader (verify the exact quant tags first)"
+        # Download is opt-in, but a run that leaves ~/models empty produces a
+        # server that serves zero models with no WARN/ERROR — surface that end
+        # state here instead of leaving it for a server.log dive (issue #4).
+        local present=0 entry
+        for entry in "${TIER_MODELS[@]}"; do
+            [ -d "$(tier_dir "$entry")" ] && { ((present++)) || true; }
+        done
+        if [ "$present" -eq 0 ]; then
+            record_warn "model" "download is opt-in and no model is on disk — the server will serve ZERO models until you run: ./setup-omlx-m5.sh --download-model (then pin/alias in /admin)"
+        else
+            skip "model" "download is opt-in — ${present} tier(s) already on disk; re-run with --download-model to fetch the rest, or use the /admin downloader"
+        fi
         return
     fi
     # All three ADR-006 tiers. download_model() skips any dir that is already

--- a/templates/omlxctl
+++ b/templates/omlxctl
@@ -75,6 +75,18 @@ _have_curl() { command -v curl >/dev/null 2>&1; }
 
 _health_ok() { _have_curl && curl -sf --max-time 3 "$HEALTH_URL" >/dev/null 2>&1; }
 
+# Print the integer "model_count" from /health (no auth key needed), or nothing
+# if curl is unavailable, the probe fails, or the field is absent. POSIX BRE so
+# it is portable to macOS/BSD sed; matches only unsigned integers. Callers MUST
+# guard the assignment (mc="$(_model_count)" || mc="") — a non-zero return would
+# otherwise abort the script under set -e.
+_model_count() {
+    _have_curl || return 1
+    local body
+    body="$(curl -sf --max-time 3 "$HEALTH_URL" 2>/dev/null)" || return 1
+    printf '%s' "$body" | sed -n 's/.*"model_count"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p'
+}
+
 # Poll /health until ready or READY_TIMEOUT elapses. Returns 0 ready, 1 timed out.
 _wait_ready() {
     if ! _have_curl; then
@@ -171,7 +183,7 @@ cmd_status() {
         info "launchd:  NOT REGISTERED (no job in gui/${UID_VAL} — run setup-omlx-m5.sh or log in)"
         return 0
     fi
-    local out state pid
+    local out state pid mc
     out="$(launchctl print "$TARGET" 2>/dev/null || true)"
     state="$(printf '%s\n' "$out" | awk '/^[[:space:]]*state = /{sub(/.*state = /,""); print; exit}')"
     pid="$(printf '%s\n'   "$out" | awk '/^[[:space:]]*pid = /{print $3; exit}')"
@@ -185,6 +197,16 @@ cmd_status() {
             info "health:   (curl not found — cannot probe ${HEALTH_URL})"
         elif _health_ok; then
             ok "ready" "responding at ${HEALTH_URL}"
+            # A healthy server with zero models loaded looks "up" but 404s every
+            # request — surface it here instead of in server.log (issue #4).
+            mc="$(_model_count)" || mc=""
+            if [ -z "$mc" ]; then
+                detail "model_count not present in /health response"
+            elif [ "$mc" -eq 0 ] 2>/dev/null; then
+                warn "models" "server healthy but 0 models loaded — run: ./setup-omlx-m5.sh --download-model, then pin/alias in /admin"
+            else
+                ok "models" "${mc} model(s) loaded"
+            fi
         else
             warn "ready" "process up but ${HEALTH_URL} not responding (still loading the model?)"
         fi


### PR DESCRIPTION
## Summary

Makes the zero-model end state self-evident instead of buried in `server.log`. After a `./setup-omlx-m5.sh` run without `--download-model` (download is opt-in by design), the server starts healthy but serves zero models — every request 404s — with no `WARN`/`ERROR` anywhere. This was a real diagnosis on an M5 Max provisioning run. Closes #4.

Two complementary surfaces, both non-fatal `WARN`s following the Script Output Conventions:

1. **`templates/omlxctl` (`status`)** — when the server is up and `/health` responds, read `model_count` from `/health` (no auth key needed) and emit `WARN [models]` when it is zero, pointing at the remediation; `OK [models] N model(s) loaded` otherwise. This is the highest-value surface — `status` is where an operator already looks. A new `_model_count()` helper parses the integer with POSIX BRE `sed` (no `jq`/`python3` dependency, bash-3.2/BSD-sed safe).
2. **`setup-omlx-m5.sh` (`maybe_download_models`)** — when download is opt-in and no tier dir is on disk, upgrade the `SKIP [model]` to `record_warn [model]` naming the consequence (server serves ZERO models). If some tiers are already present, it stays a `SKIP`. Opt-in download behavior is unchanged — this is visibility only.

## Type of Change

- [x] `feat` — new feature (new observable zero-model warning)
- [ ] `fix`
- [ ] `docs`
- [ ] `chore`
- [ ] `refactor`
- [ ] `test`
- [ ] `ci`
- [ ] `style`
- [ ] Breaking change

## Test Plan

- `shellcheck` (via `linter` agent) on both changed scripts — **PASS, 0 findings** (error/warning/info/style).
- `shell-expert` design review of the `_model_count` extraction — confirmed POSIX BRE portability and caught a real `set -e` abort hazard on the unguarded command-substitution assignment, fixed with `mc="$(_model_count)" || mc=""`.
- Logic walkthrough of all branches (curl absent, probe fail, field absent, count 0, count >0; disk: zero tiers vs some tiers).
- Runtime smoke-test of the live `WARN` requires a running oMLX server on the M5 Max host and is deferred to the operator — `omlxctl status` against a zero-model server should now print `WARN  [models] ...`.

## Doc-Impact

| Surface | Classification | Note |
| --- | --- | --- |
| `templates/omlxctl` | in-scope | the change |
| `setup-omlx-m5.sh` | in-scope | the change |
| `CLAUDE.md` (omlxctl status line) | in-scope | noted "warns on 0 models" |
| `README.md` (omlxctl status line) | in-scope | noted "warns if 0 models loaded" |
| ADR | not-a-thing | follows existing Script Output Conventions; visibility enhancement, no convention/decision change |

## Checklist

- [x] No secrets or credentials in the diff (`/health` needs no API key; nothing printed)
- [x] `WARN` to stderr, 6-char label, increments `warn_count`, non-fatal (exit code unchanged)
- [x] bash-3.2 / macOS-default-tools safe (no `jq`/`python3`; POSIX BRE sed)
- [x] `omlxctl` change lands in the static template (installed verbatim, no placeholder substitution)
