### PR TITLE
chore: promote dev to main

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,24 @@
+name: lint-pr-title
+
+# Enforces a Conventional Commits PR title. In the squash-merge flow the PR
+# title becomes the commit message on dev, so this gates commit hygiene at the
+# source. The job is named `lint-pr-title` and is a required status check on the
+# protect-dev ruleset — do NOT rename it without updating that ruleset.
+
+on:
+  pull_request:
+    branches: [dev, main]
+    # `edited` is required so a title corrected after open is re-checked.
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint-pr-title:
+    name: lint-pr-title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,8 +25,13 @@ jobs:
       # ubuntu-latest pre-installs shellcheck. Explicit file list: it covers the
       # extensionless templates/omlxctl (dialect auto-detected from its bash
       # shebang) without a find-by-shebang sweep that could pick up new files.
+      # --severity=warning gates on error/warning findings; the repo's intentional
+      # info-level idioms (SC2015 `A && B || true`, `((counter++)) || true` per the
+      # Script Output Conventions) do not fail CI. Passed explicitly rather than via
+      # .shellcheckrc because the runner's shellcheck does not reliably auto-discover
+      # the rc file; .shellcheckrc carries the same setting for local runs.
       - name: Shell lint (shellcheck)
-        run: shellcheck setup-omlx-m5.sh templates/omlx-start-wrapper.sh templates/omlxctl
+        run: shellcheck --severity=warning setup-omlx-m5.sh templates/omlx-start-wrapper.sh templates/omlxctl
 
       # Config (.markdownlint-cli2.jsonc) is auto-discovered from the repo root.
       - name: Markdown lint (markdownlint-cli2)

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,54 @@
+name: validate
+
+# Lint gate for the provisioning repo. Runs on PRs targeting dev and main, and
+# on pushes to those branches. The job is named `validate` and is wired as a
+# required status check on both the protect-dev and protect-main rulesets — do
+# NOT rename the job without updating those rulesets (the check context is the
+# job name). See adrs/007-ci-rulesets-and-release-strategy.md.
+
+on:
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [dev, main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # ubuntu-latest pre-installs shellcheck. Explicit file list: it covers the
+      # extensionless templates/omlxctl (dialect auto-detected from its bash
+      # shebang) without a find-by-shebang sweep that could pick up new files.
+      - name: Shell lint (shellcheck)
+        run: shellcheck setup-omlx-m5.sh templates/omlx-start-wrapper.sh templates/omlxctl
+
+      # Config (.markdownlint-cli2.jsonc) is auto-discovered from the repo root.
+      - name: Markdown lint (markdownlint-cli2)
+        uses: DavidAnson/markdownlint-cli2-action@v23
+        with:
+          globs: "**/*.md"
+
+      # plutil is macOS-only and unavailable on ubuntu runners; python3's stdlib
+      # ElementTree gives a portable XML well-formedness check for the plists.
+      # templates/pi-models-omlx.json is a JSONC template with __PLACEHOLDER__
+      # tokens — not parseable as JSON, so it is intentionally not validated here.
+      - name: Plist XML validation (well-formedness)
+        run: |
+          python3 - templates/com.local.omlx.plist templates/com.local.iogpu-wired-limit.plist <<'EOF'
+          import sys, xml.etree.ElementTree as ET
+          ok = True
+          for f in sys.argv[1:]:
+              try:
+                  ET.parse(f)
+                  print(f"OK    [plist] {f}")
+              except Exception as e:
+                  print(f"ERROR [plist] {f}: {e}", file=sys.stderr)
+                  ok = False
+          sys.exit(0 if ok else 1)
+          EOF

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,16 @@
+{
+  // Lint config for the validate workflow (markdownlint-cli2). Rules disabled
+  // below are noise against this repo's content, not quality gaps — see
+  // adrs/007-ci-rulesets-and-release-strategy.md for the per-rule rationale.
+  "config": {
+    "default": true,
+    "MD013": false, // line-length: technical docs carry long shell cmds, URLs, HF repo IDs
+    "MD018": false, // no-missing-space-atx: false-positive on `#1378)`-style issue refs in prose
+    "MD033": false, // no-inline-html: MADR template uses <option>/<YYYY-MM-DD> placeholders
+    "MD036": false, // no-emphasis-as-heading: bold sub-labels in older ADRs
+    "MD041": false, // first-line-heading: agent wrapper files open with prose, not a heading
+    "MD060": false  // table-column-style: compact-pipe tables are intentional
+  },
+  "globs": ["**/*.md"],
+  "ignores": ["**/node_modules/**"]
+}

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,9 @@
+# shellcheck config for the validate CI gate (and local runs).
+#
+# Gate at warning severity: error + warning findings fail the build; info/style
+# advisories do not. This repo's scripts intentionally use idioms shellcheck
+# flags only at info level — notably `A && B || true` (SC2015) in the ok/skip/
+# warn/detail helpers and `((counter++)) || true` counters mandated by the
+# Script Output Conventions. Those are deliberate, not defects, so they must not
+# fail CI. All three scripts are clean at this threshold. (ADR-007)
+severity=warning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,13 +131,20 @@ best-current-model review.
   repository-resident `omlx-expert` domain agent (oMLX runtime + MLX model
   selection + Apple-Silicon memory tuning), read-only/advisory, in both Claude
   Code and GitHub Copilot wrapper formats. Keep the two wrappers in sync.
+- `.github/workflows/` — CI lint gate (`validate.yml`: shellcheck + markdownlint +
+  plist well-formedness; `lint-pr-title.yml`: Conventional Commits PR title). The
+  `validate` and `lint-pr-title` job names are required-check contexts on the
+  `protect-dev`/`protect-main` rulesets — renaming a job breaks its ruleset binding
+  (`007`). `.markdownlint-cli2.jsonc` (repo root) configures the markdown step.
 - `adrs/` — `006-multi-tier-coresident-lineup-stay-on-omlx.md` records the current
   model lineup (superseding `004`, which superseded `003` → `002` → `001`; the
   `--memory-guard-gb`/wired-limit/concurrency from `002` and the oMLX runtime from
   `001` carry forward); `005-on-demand-service-lifecycle.md` records the on-demand
   start/stop lifecycle (no login autostart) — additive, still in force under `006`;
-  `TEMPLATE.md` is the MADR minimal template for new ADRs (sequential, zero-padded
-  three digits). The decision rationale lives in `docs/runtime-tiering-research.md`.
+  `007-ci-rulesets-and-release-strategy.md` records the CI gate, branch-protection
+  rulesets, and the deferred-`semantic-release` decision; `TEMPLATE.md` is the MADR
+  minimal template for new ADRs (sequential, zero-padded three digits). The model
+  decision rationale lives in `docs/runtime-tiering-research.md`.
 - `docs/router-wiring.md` — wiring the server into the .NET `IInferenceBackend` /
   `FallbackInferenceRouter`.
 - `README.md` — the public-facing quickstart (clone → run → validate → connect).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,9 @@ best-current-model review.
   plist well-formedness; `lint-pr-title.yml`: Conventional Commits PR title). The
   `validate` and `lint-pr-title` job names are required-check contexts on the
   `protect-dev`/`protect-main` rulesets — renaming a job breaks its ruleset binding
-  (`007`). `.markdownlint-cli2.jsonc` (repo root) configures the markdown step.
+  (`007`). `.markdownlint-cli2.jsonc` configures the markdown step; `.shellcheckrc`
+  (both repo root) gates shellcheck at `severity=warning` so the intentional
+  `A && B || true` / `((counter++)) || true` idioms (info-level SC2015) don't fail CI.
 - `adrs/` — `006-multi-tier-coresident-lineup-stay-on-omlx.md` records the current
   model lineup (superseding `004`, which superseded `003` → `002` → `001`; the
   `--memory-guard-gb`/wired-limit/concurrency from `002` and the oMLX runtime from

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ After a reboot or login, run `omlxctl start` to bring the server back.
 | [`macos/local-llm-mac-os-creation.md`](macos/local-llm-mac-os-creation.md) | The authoritative implementation brief |
 | [`adrs/`](adrs/) | Decision records — current model lineup is [ADR-006](adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md) (two co-resident pinned tiers + one on-demand max tier, stay on oMLX; supersedes [ADR-004](adrs/004-single-text-only-model-no-override.md)) and [ADR-005](adrs/005-on-demand-service-lifecycle.md) (on-demand lifecycle, no login autostart) |
 | `.claude/agents/`, `.github/agents/` | Repository-resident `omlx-expert` domain agent (read-only/advisory) for Claude Code and GitHub Copilot |
+| [`.github/workflows/`](.github/workflows/) | CI lint gate — `validate` (shellcheck + markdownlint + plist well-formedness) and `lint-pr-title` (Conventional Commits), required checks on the branch rulesets ([ADR-007](adrs/007-ci-rulesets-and-release-strategy.md)) |
 | [`docs/router-wiring.md`](docs/router-wiring.md) | Wiring the server into a .NET `IInferenceBackend` / `FallbackInferenceRouter` |
 | [`docs/runtime-tiering-research.md`](docs/runtime-tiering-research.md) | Research note behind [ADR-006](adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md) — runtime reassessment, on-host bake-off, and tier selection |
 | [`omlx-setup-prompt.md`](omlx-setup-prompt.md) | Historical source prompt only — not a source of truth |

--- a/adrs/007-ci-rulesets-and-release-strategy.md
+++ b/adrs/007-ci-rulesets-and-release-strategy.md
@@ -43,6 +43,10 @@ Concretely:
     list, dialect auto-detected from its bash shebang), `markdownlint-cli2` with a
     repo-root `.markdownlint-cli2.jsonc`, and a `python3` ElementTree plist
     well-formedness check (`plutil` is macOS-only and absent on Linux runners).
+    `shellcheck` is gated at `severity=warning` via a repo-root `.shellcheckrc`:
+    error/warning findings fail the build, while the repo's intentional info-level
+    idioms (`A && B || true` and `((counter++)) || true`, mandated by the Script
+    Output Conventions) do not.
     `templates/pi-models-omlx.json` is a JSONC template with `__PLACEHOLDER__`
     tokens and is intentionally not JSON-validated.
   - `lint-pr-title` (`.github/workflows/lint-pr-title.yml`):

--- a/adrs/007-ci-rulesets-and-release-strategy.md
+++ b/adrs/007-ci-rulesets-and-release-strategy.md
@@ -1,0 +1,86 @@
+# ADR-007: CI lint gate, branch-protection rulesets, and a deferred release strategy
+
+- Status: accepted
+- Date: 2026-06-26
+
+Resolves [issue #6](https://github.com/psmfd/local-llm/issues/6). Operationalizes
+the global GitHub Flow and SemVer Tagging conventions for this repo; nothing in
+the runtime/model decisions (ADR-001 through ADR-006) is affected.
+
+## Context and Problem Statement
+
+The repository had no CI workflows and no branch-protection rulesets: GitHub
+Actions had never run, and neither `dev` nor `main` was protected. The GitHub Flow
+guardrails the project assumes — squash-only into `dev`, merge-commit-only
+promotions to `main`, required status checks, blocked force-push and deletion —
+rested entirely on operator discipline. How should this provisioning repo (shell
+scripts + docs; no package, container, or published artifact) enforce its flow,
+and should it adopt automated releases now?
+
+## Considered Options
+
+- **CI scope:** (a) port the agent-framework's full check set (`validate.sh`,
+  `artifact-review-guard`, .NET/Helm lints) vs. (b) a repo-appropriate lint gate
+  (shellcheck + markdownlint + plist well-formedness) plus a Conventional Commits
+  PR-title check.
+- **Release automation:** (a) wire `semantic-release` now, (b) defer it and cut a
+  manual annotated `v0.1.0` from `main` after this lands, (c) no tagging at all.
+
+## Decision Outcome
+
+Chosen option: **a repo-appropriate lint gate (CI scope b) + branch-protection
+rulesets, with `semantic-release` deferred (release option b)**, because the
+agent-framework's exact checks do not transfer (there is no `validate.sh`, no
+`.review/` flow, and no .NET/Helm here), and the project has no versioned-artifact
+consumers or changelog audience that would justify a Node.js release toolchain in
+a shell-script repo.
+
+Concretely:
+
+- **CI** — two workflows on PRs to `dev`/`main`:
+  - `validate` (`.github/workflows/validate.yml`): `shellcheck` over the three
+    shell files (the extensionless `templates/omlxctl` included via an explicit
+    list, dialect auto-detected from its bash shebang), `markdownlint-cli2` with a
+    repo-root `.markdownlint-cli2.jsonc`, and a `python3` ElementTree plist
+    well-formedness check (`plutil` is macOS-only and absent on Linux runners).
+    `templates/pi-models-omlx.json` is a JSONC template with `__PLACEHOLDER__`
+    tokens and is intentionally not JSON-validated.
+  - `lint-pr-title` (`.github/workflows/lint-pr-title.yml`):
+    `amannn/action-semantic-pull-request@v6` enforcing a Conventional Commits PR
+    title (the squash commit message on `dev`).
+- **Rulesets** — `protect-dev` (require PR, 0 approvals, squash-only, linear
+  history, block force-push + deletion, required checks `validate` +
+  `lint-pr-title`) and `protect-main` (require PR, 0 approvals, merge-commit-only,
+  block force-push + deletion, required check `validate`). `protect-main`
+  **deliberately omits** the require-linear-history rule: a `dev` → `main`
+  promotion is a merge commit (non-linear by definition), and requiring linear
+  history would permanently block every promotion.
+- **Repo settings** — disable rebase merging and enable auto-delete-branch-on-merge
+  (squash + merge-commit stay enabled).
+- **Required-check binding order** — the workflows must run once (on the PR that
+  introduces them) before the ruleset can bind their check contexts; the rulesets
+  are therefore created after that PR merges, using the check-run names read back
+  from the API.
+- **Release** — defer `semantic-release`. Cut a manual annotated `v0.1.0` from
+  `main` after the first post-CI promotion. Revisit automation when a versioned
+  artifact (container image, published download) or an external consumer/changelog
+  audience appears.
+
+### Consequences
+
+- Good, because the flow is now enforced at the remote (force-push/deletion
+  blocked, merge method constrained per branch, a green lint gate required) rather
+  than relying on discipline.
+- Good, because the lint gate matches the repo's actual content and stays
+  dependency-light (no Node release toolchain, no macOS-only tooling in CI).
+- Good, because `protect-main` keeps merge-commit promotions working — the
+  highest-risk misconfiguration (linear history on `main`) is explicitly avoided.
+- Bad (accepted), because 0 required approvals is weaker than a reviewed gate —
+  unavoidable for a solo maintainer (GitHub forbids self-approval). Bump
+  `protect-dev` to 1 approval when a collaborator joins.
+- Bad (accepted), because deferring `semantic-release` means versioning is manual
+  and easy to forget; the low commit velocity and absence of downstream consumers
+  make this an acceptable trade today.
+- Bad (accepted), because the job names (`validate`, `lint-pr-title`) are now a
+  contract with the rulesets — renaming a job without updating its ruleset breaks
+  the required-check binding and blocks merges until reconciled.


### PR DESCRIPTION
## Summary

Release promotion of `dev` → `main`, bringing the CI lint gate, branch-protection ruleset config, and ADR-007 onto the stable branch (issue #6 work). This is the first promotion under the new `protect-main` ruleset — it requires the `validate` check and a merge-commit merge.

Promotes (1 feature PR + its CI fixups):

| PR | Change |
| --- | --- |
| #10 | `ci`: lint workflows (`validate`, `lint-pr-title`), `.markdownlint-cli2.jsonc`, `.shellcheckrc`, ADR-007 |

## Type of Change

- [ ] `feat`
- [ ] `fix`
- [ ] `docs`
- [x] `chore` — maintenance (release promotion)
- [ ] `refactor`
- [ ] `test`
- [ ] `ci`
- [ ] `style`
- [ ] Breaking change

## Test Plan

No testable behavior changed by the promotion itself — the CI work was reviewed and went green on PR #10. The `validate` workflow re-runs on this PR (it triggers on `pull_request` to `main`) and is a required check on `protect-main`.

## Merge Instructions

**Merge with "Create a merge commit"** — NOT squash (`protect-main` enforces merge-commit-only; squash would also diverge SHAs).

## Post-merge

Per ADR-007, cut the first annotated tag from `main` once this lands:
`git tag -a v0.1.0 -m "v0.1.0" && git push origin v0.1.0` (+ a GitHub Release).

## Checklist

- [x] No secrets in the diff
- [x] Merge method is "Create a merge commit"
- [x] Promoted commits already merged + reviewed + CI-green on `dev`
