### PR TITLE
docs(adr): add ADR-009 single-model workhorse with cloud frontier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,14 @@ runtime reassessment, on-host bake-off, and tier selection — is in
 `omlx-setup-prompt.md` is retained only as the historical source prompt; do not
 copy it forward as an additional source of truth.
 
+[`adrs/009-mac-single-workhorse-cloud-frontier.md`](adrs/009-mac-single-workhorse-cloud-frontier.md)
+records a **forward direction** — reframing the Mac as a *single-model subagent
+workhorse* with the cloud as the frontier (ADR-006's three tiers collapse to one
+pinned 3B-active MoE; the AMD appliance of ADR-008 is absorbed). It is
+**additive: it supersedes nothing yet**, so ADR-006 remains the implemented
+lineup until the model-selection probes pass and the rework lands
+([#14](https://github.com/psmfd/local-llm/issues/14)).
+
 ## Commands
 
 The deliverable is `setup-omlx-m5.sh` (idempotent; author-side, run by the user):
@@ -151,7 +159,12 @@ best-current-model review.
   `001` carry forward); `005-on-demand-service-lifecycle.md` records the on-demand
   start/stop lifecycle (no login autostart) — additive, still in force under `006`;
   `007-ci-rulesets-and-release-strategy.md` records the CI gate, branch-protection
-  rulesets, and the deferred-`semantic-release` decision; `TEMPLATE.md` is the MADR
+  rulesets, and the deferred-`semantic-release` decision;
+  `008-cross-host-routing-integration.md` integrates the second AMD host and
+  AMD-first `coding-fast` routing — additive, extends `006`;
+  `009-mac-single-workhorse-cloud-frontier.md` records the forward-direction
+  single-model workhorse reframe (cloud as frontier) — additive, supersedes
+  nothing yet (implementation tracked in #14); `TEMPLATE.md` is the MADR
   minimal template for new ADRs (sequential, zero-padded three digits). The model
   decision rationale lives in `docs/runtime-tiering-research.md`.
 - `docs/router-wiring.md` — wiring the server into the .NET `IInferenceBackend` /

--- a/adrs/009-mac-single-workhorse-cloud-frontier.md
+++ b/adrs/009-mac-single-workhorse-cloud-frontier.md
@@ -1,0 +1,157 @@
+# ADR-009: Mac as a single-model subagent workhorse, with the cloud as the frontier
+
+- Status: accepted
+- Date: 2026-06-29
+
+This ADR is **additive and supersedes nothing** (see "Relationship to prior ADRs"
+below). [ADR-006](006-multi-tier-coresident-lineup-stay-on-omlx.md) (three-tier
+co-resident lineup) and [ADR-008](008-cross-host-routing-integration.md)
+(cross-host AMD routing) remain the record of the currently-implemented state;
+this ADR records a forward direction whose implementation is tracked in
+[#14](https://github.com/psmfd/local-llm/issues/14).
+
+## Context and Problem Statement
+
+ADR-006 stood the Mac up as a three-tier, fidelity-by-workload lineup (two
+co-resident pinned coders plus an on-demand "max" quality tier), and ADR-008
+added a second always-on AMD vLLM appliance, routing `coding-fast` AMD-first and
+treating the remote `coding-quality`/fallback backend as that appliance. The
+use-case has since been reframed: a **cloud provider is the frontier** (the
+high-fidelity quality tier), and the Mac's sole remaining job is to be a **local
+subagent workhorse** — serving an orchestrator's fan-out of many concurrent
+subagent requests that share long system prefixes (routine coding tool-chains:
+reads/edits, search, codegen, summarization, structured tool-calling). What
+single-host configuration best serves that workhorse role, where concurrent
+throughput, prefix-cache reuse, and tool-call reliability matter far more than
+single-stream quality?
+
+## Considered Options
+
+- **Keep ADR-006's three-tier co-resident lineup.** Rejected: the on-host quality
+  tier is redundant once the cloud is the frontier, and it spends ~45 GB that the
+  fan-out could use as KV headroom.
+- **Keep two co-resident workhorses (T1 + T2).** Rejected: KV caches are
+  model-specific, so a homogeneous fan-out gains nothing from a second model — it
+  halves each model's prefix-cache hit rate and KV headroom while adding routing
+  complexity.
+- **Run a single larger gate-passing coder (40–70 GB) for higher quality.**
+  Rejected: decode on the unified-memory bus is bandwidth-bound; a dense ~70B
+  reads ~20× more weight per token than a 3B-active MoE for no concurrency gain,
+  and the one plausible candidate (Qwen2.5-Coder-72B) fails oMLX tool-call
+  parsing. The 3B-active MoE class is the bandwidth-optimal workhorse.
+- **A MiniMax model (Text-01, M1, M2.x, M3).** Rejected (3-agent evaluation
+  2026-06-29): MiniMax-Text-01/M1 use lightning (linear) attention — the same
+  recurrent-state / prefix-cache incompatibility as DeltaNet — and have no Metal
+  kernel; the full-attention M2 family (M2.5 = 80.2% SWE-bench) is
+  prefix-cache-safe but size-gated (smallest viable MLX build ~92.9 GB leaves
+  ~3 GB KV; 4-bit ~129 GB exceeds 128 GB RAM); M3 is a multimodal VLM (oMLX
+  engine trap) at ~240 GB. **None fit the local host.** M2.5/M3 are elite coders,
+  so they are noted instead as **cloud-frontier backend candidates**, not
+  workhorse candidates.
+- **Single pinned 3B-active MoE workhorse (chosen).**
+
+## Decision Outcome
+
+Chosen option: **a single pinned, text-only, 3B-active MoE coder on oMLX**,
+because it gives the fan-out one shared prefix cache, 2–4× more KV headroom than
+the ADR-006 pair, and never exercises oMLX's buggy multi-model swap path — while
+keeping every tool-call path verified on oMLX.
+
+**Model (CONFIRMED 2026-06-29 — gate resolved):** **`mlx-community/GLM-4.7-Flash-8bit`**.
+The MLA-compression gate that was provisional at drafting is now **verified on-host**:
+GLM's measured KV footprint matches Qwen-30B's GQA (~25× below an MHA fallback), so
+oMLX's `mlx-lm` build runs MLA-compressed — GLM is adopted, the Qwen fallback is not
+needed. GLM-4.7-Flash leads on the metrics that define the workhorse role
+(tool-sequencing τ² 79.5% vs 49.0%, hallucination 6% vs 21%, SWE-bench 59.2% vs
+~51.6%). `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` is retained on
+disk as the verified fallback (GQA, prefix-cache-safe, tool-clean) should GLM ever
+regress.
+
+**Serving config (changes from ADR-006 in bold):**
+
+- single model, `is_pinned: true`, `model_type_override: null` (both candidates
+  are pure `*ForCausalLM`, no `vision_config` — they route to the batched LLM
+  engine with no override)
+- `--memory-guard-gb 90` (unchanged); Metal wired limit 96 GB (unchanged —
+  bandwidth, not KV memory, is the binding constraint at practical concurrency;
+  pushing to 100–104 GB buys <5%)
+- **`--hot-cache-max-size 24GB`** (up from 18 GB — one model, no second cache to
+  fund)
+- **`--max-concurrent-requests 10`** — **"The Mark"**, set from on-host validation
+  (see Validation results). The earlier theoretical "48" was wrong: the binding
+  constraint under concurrent fan-out is **prefill-activation memory**, not KV.
+  Safe concurrency is **inversely tied to context length** — measured clean ceiling
+  is ≥15 @ ~9K ctx, ≥12 @ ~12K, **10 @ ~16K** (12 aborts at 16K). 10 holds across
+  the realistic subagent context range and sits ~2× above the 4–8 steady load;
+  the admission cap makes excess requests queue, and the memory guard aborts any
+  overflow gracefully (HTTP 500, no crash).
+- **Generous `max_tokens` required** — GLM-4.7-Flash emits a reasoning preamble
+  before the tool call; `max_tokens` must be ≥ ~200 (120 truncated mid-call in
+  testing) or the orchestrator must disable "thinking" if a flag exists.
+- DFlash SSD cache stays disabled (oMLX #702/#1892)
+
+**Validation results (on-host, M5 Max, 2026-06-29):**
+
+1. **MLA-compression — PASS.** Isolated GLM server, ~7.3K-token prompt: KV
+   footprint ≈ Qwen-30B GQA (GLM +214 MB vs Qwen +252 MB during decode; vmmap
+   peak +2.87 GB ≪ the >7 GB an MHA fallback would require). oMLX runs GLM
+   MLA-compressed → **GLM adopted**.
+2. **Tool-call fidelity under cache-hit concurrency — PASS (to the memory limit).**
+   Prefix reuse confirmed (`cached_tokens` ≈ 8,960/9,228 on repeat). At N ≤ 12 /
+   ~9–12K ctx, every concurrent request returned a well-formed `tool_call` with
+   valid args on a confirmed cache hit — no `#825`-style prose degradation.
+3. **Concurrency ceiling — "The Mark" = 10.** A hard prefill-activation cliff
+   exists (memory guard aborts above it): clean to N≥15 @ ~9K, ≥12 @ ~12K, **10 @
+   ~16K**; N=12 aborts at ~16K. `--max-concurrent-requests` set to 10 for
+   robustness across the context range.
+
+Outstanding (non-blocking): the GLM-4.7-Flash SWE-bench figure (59.2%) is weakly
+sourced; validate output precision on real orchestrator prompts in use.
+
+The model decision rationale lives in `docs/runtime-tiering-research.md`; the
+workhorse-reframe investigation (single-vs-dual, concurrency/bandwidth ceiling,
+subagent workload profile) was produced by the parallel-agent research behind
+this ADR.
+
+## Relationship to prior ADRs (additive — supersedes nothing)
+
+This ADR is recorded as a **forward direction**, not a supersession. ADR-006
+(three-tier lineup) and ADR-008 (cross-host AMD routing) are left **untouched and
+remain the record of the currently-implemented state** until the gates above pass
+and `setup-omlx-m5.sh` is reworked (#14). The intended end-state this ADR adopts:
+
+- the **Mac single-workhorse absorbs the local executor / `coding-fast` role**,
+- the **AMD appliance (ADR-008) is repurposed or deprecated**, and
+- the **cloud provider becomes the frontier / quality tier** in the
+  `FallbackInferenceRouter`.
+
+Formal supersession of ADR-006/008 is **deferred to the implementation PR (#14)**
+so the record does not assert a teardown ahead of the validated change. Until
+then, a reader should treat ADR-009 as the current *intent* and ADR-006/008 as
+the current *implementation*.
+
+### Consequences
+
+- Good, because the fan-out gets one shared prefix cache and ~60 GB KV headroom
+  (vs ~29 GB), and the single pinned model never triggers oMLX swap bugs
+  (#1970/#1938).
+- Good, because the workhorse role is matched to the bandwidth-optimal 3B-active
+  MoE class and keeps every tool-call path verified on oMLX, at 8-bit for
+  tool-call reliability.
+- Good, because the dominant subagent UX lever — warm-prefix TTFT — is exactly
+  what a single shared cache maximizes.
+- Bad / accepted trade-offs:
+  - **No on-host quality tier** — high-fidelity work now depends on cloud
+    reachability; a cloud outage drops the frontier with no local quality
+    backstop.
+  - **Single point of serving** on the Mac for the local tier.
+  - **Concurrency is prefill-activation-bound and context-dependent** — "The Mark"
+    (10) falls as context grows; very long shared prefixes (>16K) at high fan-out
+    hit the memory guard. Mitigated by the admission cap (excess queues) and
+    graceful guard aborts, but the orchestrator should keep subagent prefixes
+    modest.
+  - GLM-4.7-Flash's quality figure (59.2% SWE-bench) is weakly sourced; output
+    precision on real orchestrator prompts is still to be confirmed in use.
+  - Deferring formal supersession leaves ADR-006/008 co-existing with this record
+    until #14 lands; the intent-vs-implementation split must be read carefully in
+    the interim.

--- a/docs/router-wiring.md
+++ b/docs/router-wiring.md
@@ -5,6 +5,14 @@ behind your `FallbackInferenceRouter`, routing the three local tiers
 (`coding-fast`, `coding-balanced`, `coding-quality`) → oMLX and falling through to
 a remote backend on failure or saturation.
 
+> **Forward direction — [ADR-009](../adrs/009-mac-single-workhorse-cloud-frontier.md)
+> (additive, pending implementation #14).** A reframe collapses the Mac to a
+> *single* GLM-4.7-Flash workhorse (local executor) with the **cloud as the
+> frontier/quality tier** and the AMD peer repurposed. See
+> [ADR-009 forward direction](#adr-009-forward-direction-single-workhorse-cloud-frontier)
+> below; the ADR-006/008 multi-tier wiring described first remains the implemented
+> state until #14 lands.
+
 - **Endpoint:** `http://localhost:8000/v1` (OpenAI-style `POST /v1/chat/completions`).
   oMLX also serves Anthropic-style `POST /v1/messages`; this note uses the
   OpenAI chat-completions shape.
@@ -265,6 +273,101 @@ The AMD backend's alias dictionary contains only `coding-fast`; every other role
 throws `InferenceUnavailableException` so the chain advances — which is why **both**
 backends must throw that exception type (not `ArgumentOutOfRangeException`) for
 unserved roles. See [ADR-008](../adrs/008-cross-host-routing-integration.md).
+
+## ADR-009 forward direction: single workhorse, cloud frontier
+
+[ADR-009](../adrs/009-mac-single-workhorse-cloud-frontier.md) is **additive and not
+yet implemented** (tracked in #14); the wiring above stays in force until then. The
+forward target:
+
+- **Local Mac = one pinned GLM-4.7-Flash workhorse** serving the executor roles;
+  the AMD peer (ADR-008) is repurposed/deprecated.
+- **Cloud = the frontier**: the high-fidelity `coding-quality` role routes to a
+  cloud backend, not a local tier.
+
+Collapse the three local aliases to one workhorse model, and let the quality role
+fall through to the cloud frontier backend:
+
+```csharp
+// oMLX workhorse backend: executor roles all map to the single pinned model.
+private static readonly Dictionary<ModelRole, string> ModelAliases = new()
+{
+    [ModelRole.Fast]     = "coding-workhorse",   // single GLM-4.7-Flash alias
+    [ModelRole.Balanced] = "coding-workhorse",
+    // Quality is NOT served locally — omit it so the role throws
+    // InferenceUnavailableException and the chain advances to the cloud frontier.
+};
+```
+
+Router ordering under ADR-009:
+
+- `coding-fast` / `coding-balanced` → **Mac oMLX workhorse** primary → cloud fallback.
+- `coding-quality` → Mac throws `InferenceUnavailableException` (no local quality
+  tier) → **cloud frontier** backend (registered for the quality role).
+
+Serving/resilience notes specific to the workhorse:
+
+- oMLX runs `--max-concurrent-requests 10` (**"The Mark"**, validated on-host; the
+  safe ceiling falls as shared-prefix context grows — clean to N≥15 @ ~9K ctx but
+  10 @ ~16K, so keep subagent prefixes modest). A 429 or a memory-guard 500 trips
+  the circuit breaker → cloud.
+- GLM-4.7-Flash emits a **reasoning preamble before tool calls**; keep `max_tokens`
+  ≥ ~200 on tool-bearing requests so the call is not truncated, and keep
+  `AttemptTimeout` generous (no ~16 s cold-load tier anymore, but decode + preamble
+  still take time).
+
+## Tool-call schema-validate-and-retry guard
+
+A small local workhorse occasionally emits a malformed tool call (invalid JSON
+arguments) or — if `max_tokens` is too low — truncates before completing it. A
+single malformed call breaks an agent pipeline silently. Wrap tool-bearing
+completions in a validate-and-retry loop at the dispatcher: parse the call,
+validate its arguments against the tool's JSON schema, and on failure re-issue once
+with a structured corrective message before falling through.
+
+```csharp
+// Sketch — assumes the backend surfaces tool_calls and you hold the tool's
+// argument schema. Validates the arguments JSON; retries once on failure.
+public async Task<InferenceResponse> CompleteWithToolGuardAsync(
+    InferenceRequest request, Func<string, bool> argumentsAreValid, CancellationToken ct = default)
+{
+    var messages = request.Messages.ToList();
+    for (int attempt = 0; attempt < 2; attempt++)
+    {
+        InferenceResponse resp = await CompleteAsync(request with { Messages = messages }, ct);
+
+        // Adapt extraction to your wire shape; a null/empty call or invalid-JSON
+        // arguments is the failure we retry on.
+        string? toolArgs = TryExtractToolArguments(resp);
+        if (toolArgs is not null && argumentsAreValid(toolArgs))
+            return resp;
+
+        if (attempt == 0)
+        {
+            // One corrective turn: name what was wrong, demand a single clean call.
+            messages.Add(new ChatMessage("assistant", resp.Content));
+            messages.Add(new ChatMessage("user",
+                "The previous tool call was missing or had invalid JSON arguments. " +
+                "Return exactly one well-formed tool call matching the schema, with no other text."));
+            continue;
+        }
+
+        // Both attempts failed — advance to the next backend rather than pass a
+        // malformed call downstream.
+        throw new InferenceUnavailableException("Workhorse returned no valid tool call after one retry.");
+    }
+    throw new InvalidOperationException("unreachable");
+}
+```
+
+Notes:
+
+- Keep the retry count at **one** — the failure is usually a truncation or a
+  formatting slip the corrective turn fixes; more retries waste a fan-out slot.
+- Validate against the **actual tool schema** (required fields, types), not merely
+  "is it JSON" — the common GLM failure is a complete-but-wrong-shape object.
+- Pair with generous `max_tokens` (above); truncation is the most common cause of a
+  missing call.
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Records the **single-model subagent-workhorse** reframe as **ADR-009** (additive —
supersedes nothing yet): the Mac collapses to one pinned **GLM-4.7-Flash** workhorse,
the **cloud is the frontier/quality tier**, and the AMD peer (ADR-008) is repurposed.
The model choice is no longer provisional — it was **validated on-host** (M5 Max),
and `docs/router-wiring.md` gains the forward-direction routing plus a tool-call
schema-retry guard. Why: with cloud as the frontier, a local quality tier is
redundant, and the freed memory plus a single shared prefix cache is the right shape
for a concurrent subagent fan-out.

## On-host validation (the test evidence)

- **MLA compression — PASS.** GLM's KV footprint ≈ Qwen-30B GQA (~25× below an MHA
  fallback) → oMLX runs GLM MLA-compressed → **GLM adopted** (gate resolved).
- **Tool-call fidelity under cache-hit concurrency — PASS.** Prefix reuse confirmed
  (`cached_tokens` ≈ 8,960/9,228); clean well-formed tool calls at N ≤ 12 — no
  `#825`-style prose degradation.
- **Concurrency "The Mark" = 10.** Prefill-activation cliff; safe N falls with
  context (≥15 @ ~9K, ≥12 @ ~12K, 10 @ ~16K) → `--max-concurrent-requests 10`.
- **MiniMax evaluated, gated out locally** (lightning-attention or size); M2.5/M3 are
  cloud-frontier candidates.

## Type of Change

- [x] `docs` — documentation only

## Test Plan

- `markdownlint-cli2` clean on all three changed files.
- On-host probes (M5 Max) summarized above; isolated probe servers, auto-torn-down,
  the implemented ADR-006 config untouched.
- No code behavior changed (ADR + docs only).

## Doc-impact

| Surface | Classification | Note |
|---|---|---|
| `adrs/009-…md` | in-scope | the ADR (added) |
| `CLAUDE.md` | in-scope | forward-direction pointer + `adrs/` list (008 & 009) |
| `docs/router-wiring.md` | in-scope | ADR-009 routing + schema-retry guard |
| `adrs/006`, `adrs/008` | not-a-thing | additive ADR; not superseded (deliberate) |
| `README.md` | not-a-thing (this pass) | describes implemented state; syncs with #14 |
| `setup-omlx-m5.sh` + templates | out-of-scope-but-tracked | **#14** |

## Checklist

- [x] No secrets/keys committed
- [x] Markdown lint clean (changed files)
- [x] ADR follows MADR template; additive relationship stated explicitly
- [x] Implementation follow-up tracked (#14)

Closes nothing; unblocks #14.
