### PR TITLE
feat(setup): implement ADR-009 single-model workhorse lineup

### DIFF
--- a/.claude/agents/omlx-expert.md
+++ b/.claude/agents/omlx-expert.md
@@ -52,8 +52,11 @@ over single-stream tok/s). You return advice and exact commands; you never modif
 ### Model selection (128 GB, parallel coding agents)
 
 - Prefer text-only coder MoE models with strong native tool-calling and large
-  context. Current pick: `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit`
-  (~32 GB, `Qwen3MoeForCausalLM`, 262,144 native context, `rope_scaling: null`).
+  context. Current pick (ADR-009 workhorse): `mlx-community/GLM-4.7-Flash-8bit`
+  (~30 GB, `Glm4MoeLiteForCausalLM`, 202K native context, MLA KV compression —
+  verified ≈ GQA footprint on oMLX). Verified fallback kept on disk:
+  `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` (~30.6 GB,
+  `Qwen3MoeForCausalLM`, GQA, 262,144 native context, `rope_scaling: null`).
 - A single resident model maximizes the KV/prefix-cache budget under the wired
   ceiling; co-residency of two large models roughly halves it.
 - Will **not** fit 128 GB: `Qwen3-Coder-480B-A35B` (~540 GB @ 8-bit), Kimi K2.x

--- a/.github/agents/omlx-expert.agent.md
+++ b/.github/agents/omlx-expert.agent.md
@@ -54,8 +54,11 @@ over single-stream tok/s). You return advice and exact commands; you never modif
 ### Model selection (128 GB, parallel coding agents)
 
 - Prefer text-only coder MoE models with strong native tool-calling and large
-  context. Current pick: `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit`
-  (~32 GB, `Qwen3MoeForCausalLM`, 262,144 native context, `rope_scaling: null`).
+  context. Current pick (ADR-009 workhorse): `mlx-community/GLM-4.7-Flash-8bit`
+  (~30 GB, `Glm4MoeLiteForCausalLM`, 202K native context, MLA KV compression —
+  verified ≈ GQA footprint on oMLX). Verified fallback kept on disk:
+  `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` (~30.6 GB,
+  `Qwen3MoeForCausalLM`, GQA, 262,144 native context, `rope_scaling: null`).
 - A single resident model maximizes the KV/prefix-cache budget under the wired
   ceiling; co-residency of two large models roughly halves it.
 - Will **not** fit 128 GB: `Qwen3-Coder-480B-A35B` (~540 GB @ 8-bit), Kimi K2.x

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,26 +12,21 @@ requests that share long system prefixes, so **concurrent throughput and
 prefix-cache reuse matter more than single-stream tok/s**.
 
 The authoritative brief is [`macos/local-llm-mac-os-creation.md`](macos/local-llm-mac-os-creation.md);
-the current model-lineup decision is [`adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md`](adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md)
-(two co-resident pinned tiers + one on-demand max tier; stay on oMLX), which
-supersedes [`adrs/004-single-text-only-model-no-override.md`](adrs/004-single-text-only-model-no-override.md)
-and, through it, [`adrs/003-vlm-engine-workaround-lineup.md`](adrs/003-vlm-engine-workaround-lineup.md)
-and [`adrs/002-qwen36-lineup-memory-guard.md`](adrs/002-qwen36-lineup-memory-guard.md)
-(whose `--memory-guard-gb` migration, wired limit, and concurrency carry forward)
-and [`adrs/001-local-mlx-inference-omlx.md`](adrs/001-local-mlx-inference-omlx.md)
-(whose oMLX runtime choice is reaffirmed by ADR-006). The full investigation —
-runtime reassessment, on-host bake-off, and tier selection — is in
-[`docs/runtime-tiering-research.md`](docs/runtime-tiering-research.md).
+the current model-lineup decision is [`adrs/009-mac-single-workhorse-cloud-frontier.md`](adrs/009-mac-single-workhorse-cloud-frontier.md)
+(the Mac is a **single-model subagent workhorse** — one pinned 3B-active MoE,
+GLM-4.7-Flash-8bit as `coding-workhorse` — with a **cloud provider as the
+quality frontier**; implemented via [#14](https://github.com/psmfd/local-llm/issues/14)).
+ADR-009 supersedes [`adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md`](adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md)
+(the three-tier lineup) and [`adrs/008-cross-host-routing-integration.md`](adrs/008-cross-host-routing-integration.md)
+(cross-host AMD routing; the appliance is repurposed/deprecated). ADR-002's
+`--memory-guard-gb` migration and wired limit, and ADR-001's oMLX runtime
+choice, carry forward unchanged; [`adrs/005-on-demand-service-lifecycle.md`](adrs/005-on-demand-service-lifecycle.md)
+(on-demand lifecycle) remains in force. The model-selection research is in
+[`docs/runtime-tiering-research.md`](docs/runtime-tiering-research.md); the
+one-time on-host probes (long-context MLA, `enable_thinking`) are in
+[`docs/workhorse-probes.md`](docs/workhorse-probes.md).
 `omlx-setup-prompt.md` is retained only as the historical source prompt; do not
 copy it forward as an additional source of truth.
-
-[`adrs/009-mac-single-workhorse-cloud-frontier.md`](adrs/009-mac-single-workhorse-cloud-frontier.md)
-records a **forward direction** — reframing the Mac as a *single-model subagent
-workhorse* with the cloud as the frontier (ADR-006's three tiers collapse to one
-pinned 3B-active MoE; the AMD appliance of ADR-008 is absorbed). It is
-**additive: it supersedes nothing yet**, so ADR-006 remains the implemented
-lineup until the model-selection probes pass and the rework lands
-([#14](https://github.com/psmfd/local-llm/issues/14)).
 
 ## Commands
 
@@ -39,7 +34,7 @@ The deliverable is `setup-omlx-m5.sh` (idempotent; author-side, run by the user)
 
 ```bash
 ./setup-omlx-m5.sh                  # preflight + install + dirs + key + wired-limit + service + omlxctl (no model download; server NOT started)
-./setup-omlx-m5.sh --download-model # also fetch the model (~32 GB) via hf
+./setup-omlx-m5.sh --download-model # also fetch the workhorse model (~30 GB) via hf
 ./setup-omlx-m5.sh --configure-pi   # register the oMLX provider with the Pi coding agent (~/.pi/agent/models.json)
 ./setup-omlx-m5.sh --validate       # endpoint checks (models / chat / tool-call / Anthropic / 2-way concurrency) against a running server
 ./setup-omlx-m5.sh --verbose --help
@@ -54,14 +49,15 @@ omlxctl restart  # atomic restart + wait         |  omlxctl status  # launchd + 
 ```
 
 Exit codes: `0` pass, `1` errors, `2` precondition failure. Lint with the
-`linter` agent (shellcheck). The Metal wired-limit step needs `sudo`. Aliases +
-pins are applied via the **oMLX admin API** (`apply_pins` briefly starts the
-server, PUTs each tier's settings, then stops it — `model_settings.json` is
-oMLX-owned, so the script never writes it directly); it degrades to printed
-manual admin-panel steps if the API can't be reached (ADR-006).
+`linter` agent (shellcheck). The Metal wired-limit step needs `sudo`. The
+workhorse alias + pin is applied via the **oMLX admin API** (`apply_pins` briefly
+starts the server, PUTs the model's settings — and **unpins any retired ADR-006
+tiers** it finds registered — then stops it; `model_settings.json` is oMLX-owned,
+so the script never writes it directly); it degrades to printed manual
+admin-panel steps if the API can't be reached (ADR-009).
 
 Preflight hard-fails with exit `2` for non-macOS, non-arm64, RAM below ~120 GB,
-free disk below ~100 GB, or missing Homebrew. M5 Max is the tuned target; a
+free disk below ~60 GB, or missing Homebrew. M5 Max is the tuned target; a
 non-M5 Apple Silicon chip warns instead of hard-failing so nearby Max-class hosts
 can still smoke-test deliberately.
 
@@ -88,27 +84,27 @@ best-current-model review.
 
 - **Runtime:** oMLX via Homebrew —
   `brew tap jundot/omlx https://github.com/jundot/omlx && brew install omlx`
-- **Models (three tiers, all text-only; ADR-006):** every tier is a verified
-  text-only coder build (`*ForCausalLM`, no `vision_config`) and tool-call-verified
-  on oMLX, so each routes to the batched LLM engine with **no engine override**.
-  - **T1 `coding-fast`** — `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit`
-    (`Qwen3MoeForCausalLM`, MoE ~3B active, 262K ctx). ~30.6 GB. **Pinned, co-resident.**
-  - **T2 `coding-balanced`** — `mlx-community/GLM-4.7-Flash-8bit`
-    (`Glm4MoeLiteForCausalLM`, MoE ~3B active, 202K ctx). ~30 GB. **Pinned, co-resident.**
-  - **MAX `coding-quality`** — `lmstudio-community/Qwen3-Coder-Next-MLX-4bit`
-    (`Qwen3NextForCausalLM`, 80B/~3B active, ~71% SWE-bench). ~45 GB. **On-demand**
-    (lazy-loads ~16 s on first request, idle-evicts; NOT pinned — it does not
-    co-reside alongside T1+T2 under the wired ceiling).
-  T1+T2 stay co-resident (~60 GB) leaving ~29 GB for KV/prefix cache under the
-  90 GB memory guard (itself below the 96 GB wired ceiling), so the fan-out never
-  pays a swap cost. DFlash SSD cache is
-  disabled on every tier (oMLX #702/#1892).
+- **Model (single workhorse, text-only; ADR-009):** **`coding-workhorse`** —
+  `mlx-community/GLM-4.7-Flash-8bit` (`Glm4MoeLiteForCausalLM`, MoE ~3B active,
+  202K ctx, MLA KV compression — verified on-host ≈ GQA footprint). ~30 GB.
+  **Pinned, sole resident model.** A verified text-only coder build
+  (`*ForCausalLM`, no `vision_config`) and tool-call-verified on oMLX, so it
+  routes to the batched LLM engine with **no engine override**. One pinned model
+  gives the fan-out one shared prefix cache and ~60 GB KV headroom under the
+  90 GB guard (vs ~29 GB with ADR-006's pair) and never exercises oMLX's
+  multi-model swap path. DFlash SSD cache stays disabled (oMLX #702/#1892).
+  **Retired ADR-006 tiers** (`Qwen3-Coder-30B-A3B-Instruct-MLX-8bit`,
+  `Qwen3-Coder-Next-MLX-4bit`) are never downloaded/aliased/validated; setup
+  actively unpins them if a prior install left them pinned. Qwen3-Coder-30B stays
+  on disk as the documented **inactive fallback**. GLM emits a reasoning preamble —
+  tool-bearing requests need `max_tokens ≥ ~200` (validation uses 256).
 - **Serving flags:** `--host 127.0.0.1` (explicit loopback pin), port `8000`,
   `--memory-guard-gb 90` (replaces the removed `--max-process-memory`),
-  `--paged-ssd-cache-dir ~/.omlx/cache`, `--hot-cache-max-size 18GB` (oMLX accepts
-  both absolute sizes and percentages; we pin an absolute value ≈ 20% of the guard
-  for a deterministic footprint), `--max-concurrent-requests 16` (oMLX default is
-  8), `--api-key` from the 0600 file.
+  `--paged-ssd-cache-dir ~/.omlx/cache`, `--hot-cache-max-size 24GB` (oMLX accepts
+  both absolute sizes and percentages; we pin an absolute value ≈ 27% of the guard
+  for a deterministic footprint — one model, no second cache to fund),
+  `--max-concurrent-requests 10` (ADR-009 "The Mark": prefill-activation-bound,
+  measured 10 clean @ ~16K ctx; oMLX default is 8), `--api-key` from the 0600 file.
 - **Metal wired limit:** raise `iogpu.wired_limit_mb` to ~96 GB (98304); persist
   across reboot via a LaunchDaemon (sudo). The daemon stays loaded even when the
   server is stopped — it is a ceiling, not a reservation, and costs no memory idle.
@@ -126,11 +122,12 @@ best-current-model review.
   creates `~/models`, `~/.omlx/{cache,logs,bin}`; generates the 0600 API key;
   sets + persists the wired limit; installs the start wrapper + LaunchAgent (on-
   demand, RunAtLoad=false) + the `omlxctl` control tool (symlinked onto PATH when
-  the brew bin is writable); downloads the three tiers when **download is opt-in
-  (default off)**, skipping any already present (upgrade-safe); applies aliases +
-  pins via the admin API (`apply_pins`, start→pin→stop) and leaves the server
-  stopped; `--configure-pi` registers the provider with the Pi coding agent.
-  No engine override step — all tiers are text-only (ADR-006).
+  the brew bin is writable); downloads the workhorse model when **download is
+  opt-in (default off)**, skipping it if already present (upgrade-safe); applies
+  the alias + pin — and unpins retired ADR-006 tiers — via the admin API
+  (`apply_pins`, start→pin/unpin→stop) and leaves the server stopped;
+  `--configure-pi` registers the provider with the Pi coding agent.
+  No engine override step — the workhorse is text-only (ADR-009).
 - `templates/` — committed templates the script installs with placeholder
   substitution: `omlx-start-wrapper.sh`, the `com.local.omlx.plist` LaunchAgent,
   the `com.local.iogpu-wired-limit.plist` root LaunchDaemon, `omlxctl` (the
@@ -154,22 +151,22 @@ best-current-model review.
   (`007`). `.markdownlint-cli2.jsonc` configures the markdown step; `.shellcheckrc`
   (both repo root) gates shellcheck at `severity=warning` so the intentional
   `A && B || true` / `((counter++)) || true` idioms (info-level SC2015) don't fail CI.
-- `adrs/` — `006-multi-tier-coresident-lineup-stay-on-omlx.md` records the current
-  model lineup (superseding `004`, which superseded `003` → `002` → `001`; the
-  `--memory-guard-gb`/wired-limit/concurrency from `002` and the oMLX runtime from
-  `001` carry forward); `005-on-demand-service-lifecycle.md` records the on-demand
-  start/stop lifecycle (no login autostart) — additive, still in force under `006`;
+- `adrs/` — `009-mac-single-workhorse-cloud-frontier.md` records the current
+  model lineup (single pinned workhorse, cloud as frontier; implemented via #14),
+  superseding `006` (three-tier lineup — which superseded `004` → `003` → `002`
+  → `001`) and `008` (cross-host AMD routing). The `--memory-guard-gb`/wired-limit
+  from `002` and the oMLX runtime from `001` carry forward;
+  `005-on-demand-service-lifecycle.md` records the on-demand start/stop lifecycle
+  (no login autostart) — still in force under `009`;
   `007-ci-rulesets-and-release-strategy.md` records the CI gate, branch-protection
-  rulesets, and the deferred-`semantic-release` decision;
-  `008-cross-host-routing-integration.md` integrates the second AMD host and
-  AMD-first `coding-fast` routing — additive, extends `006`;
-  `009-mac-single-workhorse-cloud-frontier.md` records the forward-direction
-  single-model workhorse reframe (cloud as frontier) — additive, supersedes
-  nothing yet (implementation tracked in #14); `TEMPLATE.md` is the MADR
-  minimal template for new ADRs (sequential, zero-padded three digits). The model
-  decision rationale lives in `docs/runtime-tiering-research.md`.
+  rulesets, and the deferred-`semantic-release` decision; `TEMPLATE.md` is the
+  MADR minimal template for new ADRs (sequential, zero-padded three digits). The
+  model decision rationale lives in `docs/runtime-tiering-research.md`.
 - `docs/router-wiring.md` — wiring the server into the .NET `IInferenceBackend` /
   `FallbackInferenceRouter`.
+- `docs/workhorse-probes.md` — one-time on-host probes to run before trusting the
+  workhorse config under load (long-context MLA check, `enable_thinking`
+  pass-through).
 - `README.md` — the public-facing quickstart (clone → run → validate → connect).
   Keep it in sync when flags, model IDs, or the step order change.
 
@@ -215,10 +212,11 @@ After the server is up, validate against `http://localhost:8000/v1` (the script'
 5. A `POST /v1/messages` call confirming the Anthropic-style endpoint is reachable.
 
 Anthropic-style clients use `/v1/messages`. The downstream consumer is an
-`IInferenceBackend` / `FallbackInferenceRouter`: `coding-fast` and `coding-balanced`
-→ co-resident local models; `coding-quality` → the local on-demand max tier
-(Qwen3-Coder-Next, lazy-loaded), with a remote backend as fallback (see
-`docs/router-wiring.md`).
+`IInferenceBackend` / `FallbackInferenceRouter`: fast/balanced roles →
+`coding-workhorse` (the single pinned local model); the quality role → the
+**cloud frontier** provider, never a local tier (see `docs/router-wiring.md`).
+Tool-bearing requests need `max_tokens ≥ ~200` — GLM emits a reasoning preamble
+before the tool call (validation uses 256).
 
 ## Teardown
 
@@ -238,11 +236,12 @@ sudo rm -f /Library/LaunchDaemons/com.local.iogpu-wired-limit.plist
 # 3. Uninstall oMLX
 brew uninstall omlx && brew untap jundot/omlx
 
-# 4. Remove data (the API key + cache/logs, and the three model tiers)
+# 4. Remove data (the API key + cache/logs, the workhorse, and any retired
+#    ADR-006 tiers still on disk)
 rm -rf ~/.omlx          # includes the 0600 api-key
+rm -rf ~/models/GLM-4.7-Flash-8bit
 rm -rf ~/models/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit \
-       ~/models/GLM-4.7-Flash-8bit \
-       ~/models/Qwen3-Coder-Next-MLX-4bit
+       ~/models/Qwen3-Coder-Next-MLX-4bit   # retired tiers, if present
 ```
 
 ## Scripts

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Stand up a **local, OpenAI/Anthropic-compatible LLM inference server** on an App
 
 ## TL;DR — start now
 
-You need: an Apple Silicon Mac with **128 GB unified memory** (tuned for M5 Max; other Max-class chips warn but work), ~140 GB free disk (three model tiers ≈ 105 GB plus cache headroom), macOS, and [Homebrew](https://brew.sh). One step needs `sudo` (GPU wired-memory limit).
+You need: an Apple Silicon Mac with **128 GB unified memory** (tuned for M5 Max; other Max-class chips warn but work), ~60 GB free disk (the workhorse model ≈ 30 GB plus staging/cache headroom), macOS, and [Homebrew](https://brew.sh). One step needs `sudo` (GPU wired-memory limit).
 
 ```bash
 git clone https://github.com/psmfd/local-llm.git && cd local-llm
-./setup-omlx-m5.sh --download-model   # install + configure + fetch the 3 tiers (~105 GB)
+./setup-omlx-m5.sh --download-model   # install + configure + fetch the workhorse (~30 GB)
 omlxctl start                         # start the server on demand (NOT at login)
 ./setup-omlx-m5.sh --validate         # smoke-test the running server
 ```
@@ -23,30 +23,28 @@ The script is idempotent — re-running it skips whatever already exists. Run `.
 
 `setup-omlx-m5.sh` performs, in order:
 
-1. **Preflight** — hard-fails (exit `2`) on non-macOS, non-arm64, <~120 GB RAM, <~100 GB free disk, or missing Homebrew.
+1. **Preflight** — hard-fails (exit `2`) on non-macOS, non-arm64, <~120 GB RAM, <~60 GB free disk, or missing Homebrew.
 2. **Installs oMLX** via `brew tap jundot/omlx && brew install omlx` (no MCP — tool access stays explicit).
 3. **Creates directories** — `~/models`, `~/.omlx/{cache,logs,bin}` (`~/.omlx` is chmod 700).
 4. **Generates an API key** at `~/.omlx/api-key` (chmod 600, never printed).
 5. **Raises the Metal wired limit** to ~96 GB so the GPU can hold the model resident, persisted across reboots via a root LaunchDaemon (**the sudo step**).
 6. **Installs on-demand service control** — a start wrapper carrying the tuned serving flags, a per-user LaunchAgent (`RunAtLoad=false`, `KeepAlive=false` — registered at login but **not** started), and the `omlxctl` control tool (symlinked onto your `PATH` when the Homebrew bin is writable). Setup deliberately leaves the server stopped ([ADR-005](adrs/005-on-demand-service-lifecycle.md)).
 
-Model download is **opt-in** (`--download-model`); the base run never pulls weights. No engine override is applied — every tier is a verified text-only coder build, so oMLX runs each on its batched LLM engine and it is concurrency-safe as-is ([ADR-006](adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md)).
+Model download is **opt-in** (`--download-model`); the base run never pulls weights. No engine override is applied — the workhorse is a verified text-only coder build, so oMLX runs it on its batched LLM engine and it is concurrency-safe as-is ([ADR-009](adrs/009-mac-single-workhorse-cloud-frontier.md)).
 
-## Model tiers
+## The workhorse model
 
-Three tiers ([ADR-006](adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md)), all verified text-only (no `vision_config`) and tool-call-verified on oMLX:
+One pinned model ([ADR-009](adrs/009-mac-single-workhorse-cloud-frontier.md)) — the Mac is a **subagent workhorse** and high-fidelity work routes to a cloud frontier, not to a local tier:
 
-| Tier | Alias | Model | ~Size | Residency |
-|---|---|---|---|---|
-| fast | `coding-fast` | `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` (MoE, ~3 B active, 262 K ctx) | ~30 GB | pinned, co-resident |
-| balanced | `coding-balanced` | `mlx-community/GLM-4.7-Flash-8bit` (MoE-lite, ~3 B active, 202 K ctx) | ~30 GB | pinned, co-resident |
-| quality | `coding-quality` | `lmstudio-community/Qwen3-Coder-Next-MLX-4bit` (MoE, 80 B/~3 B active, ~71 % SWE-bench) | ~45 GB | on-demand (lazy-load ~16 s, idle-evicts) |
+| Alias | Model | ~Size | Residency |
+|---|---|---|---|
+| `coding-workhorse` | `mlx-community/GLM-4.7-Flash-8bit` (MoE, ~3 B active, 202 K ctx, MLA KV compression) | ~30 GB | pinned, sole resident |
 
-`coding-fast` + `coding-balanced` stay **co-resident and pinned** (~60 GB, leaving ~29 GB for KV/prefix cache under the 90 GB memory guard, itself below the 96 GB wired ceiling), so the parallel-agent fan-out never pays a swap cost. `coding-quality` is the genuine high-fidelity tier — it does not co-reside (45 GB + 60 GB exceeds the budget), so oMLX **lazy-loads it on first request** and evicts it when idle. The setup script applies aliases + pins via the oMLX admin API (briefly starting the server, then stopping it; falls back to printed manual steps). Re-verify the HuggingFace repo IDs against current availability before downloading — the script probes them, but better checkpoints ship often.
+A single pinned model gives the parallel-agent fan-out **one shared prefix cache and ~60 GB of KV headroom** under the 90 GB memory guard (vs ~29 GB with ADR-006's co-resident pair), and never exercises oMLX's multi-model swap path. `--max-concurrent-requests` is 10 — safe concurrency is prefill-activation-bound and falls with context length (measured 10 clean at ~16 K ctx); excess requests queue at admission. `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` may remain on disk from an earlier install as the documented **inactive fallback** — it is never downloaded, pinned, or served by default. The setup script applies the alias + pin via the oMLX admin API (briefly starting the server, then stopping it; falls back to printed manual steps) and **unpins retired ADR-006 tiers** it finds. Re-verify the HuggingFace repo ID against current availability before downloading — the script probes it, but better checkpoints ship often.
 
 ## Starting and stopping
 
-Startup is intentional — nothing wires the ~32 GB model until you ask. Control the server with `omlxctl` (installed to `~/.omlx/bin/omlxctl`, symlinked onto `PATH` when possible; otherwise call it by full path or add `~/.omlx/bin` to `PATH`):
+Startup is intentional — nothing wires the ~30 GB model until you ask. Control the server with `omlxctl` (installed to `~/.omlx/bin/omlxctl`, symlinked onto `PATH` when possible; otherwise call it by full path or add `~/.omlx/bin` to `PATH`):
 
 ```bash
 omlxctl start     # kickstart the server, then wait for /health (cold start ~90 s)
@@ -62,7 +60,7 @@ After a reboot or login, run `omlxctl start` to bring the server back.
 
 ## Validating
 
-`./setup-omlx-m5.sh --validate` runs five checks against the running server: model listing, a small chat completion, a **tool-calling** round-trip, a **2-way concurrency probe** (confirms the batched engine handles the fan-out), and an Anthropic-style `/v1/messages` call.
+`./setup-omlx-m5.sh --validate` runs five checks against the running server: model listing (including a warning if a retired ADR-006 tier is still pinned), a small chat completion, a **tool-calling** round-trip, a **2-way concurrency probe** (confirms the batched engine handles the fan-out), and an Anthropic-style `/v1/messages` call. Before trusting the config under real load, also run the one-time on-host probes in [docs/workhorse-probes.md](docs/workhorse-probes.md) (long-context MLA check, `enable_thinking` pass-through).
 
 ## Connecting clients
 
@@ -78,24 +76,24 @@ After a reboot or login, run `omlxctl start` to bring the server back.
 | [`setup-omlx-m5.sh`](setup-omlx-m5.sh) | The provisioning script (idempotent; exit codes `0` pass / `1` error / `2` precondition) |
 | [`templates/`](templates/) | Start wrapper, LaunchAgent/LaunchDaemon plists, `omlxctl` control tool, Pi provider block — installed with placeholder substitution |
 | [`macos/local-llm-mac-os-creation.md`](macos/local-llm-mac-os-creation.md) | The authoritative implementation brief |
-| [`adrs/`](adrs/) | Decision records — current model lineup is [ADR-006](adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md) (two co-resident pinned tiers + one on-demand max tier, stay on oMLX; supersedes [ADR-004](adrs/004-single-text-only-model-no-override.md)), [ADR-005](adrs/005-on-demand-service-lifecycle.md) (on-demand lifecycle, no login autostart), and [ADR-008](adrs/008-cross-host-routing-integration.md) (cross-host AMD routing — extends ADR-006). [ADR-009](adrs/009-mac-single-workhorse-cloud-frontier.md) records a **forward direction** (single-model workhorse, cloud as frontier) — additive, not yet implemented; tracked in [#14](https://github.com/psmfd/local-llm/issues/14) |
+| [`adrs/`](adrs/) | Decision records — the current lineup is [ADR-009](adrs/009-mac-single-workhorse-cloud-frontier.md) (single-model workhorse, cloud as frontier; supersedes [ADR-006](adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md) three-tier lineup and [ADR-008](adrs/008-cross-host-routing-integration.md) cross-host AMD routing), plus [ADR-005](adrs/005-on-demand-service-lifecycle.md) (on-demand lifecycle, no login autostart — still in force) |
 | `.claude/agents/`, `.github/agents/` | Repository-resident `omlx-expert` domain agent (read-only/advisory) for Claude Code and GitHub Copilot |
 | [`.github/workflows/`](.github/workflows/) | CI lint gate — `validate` (shellcheck + markdownlint + plist well-formedness) and `lint-pr-title` (Conventional Commits), required checks on the branch rulesets ([ADR-007](adrs/007-ci-rulesets-and-release-strategy.md)) |
 | [`docs/router-wiring.md`](docs/router-wiring.md) | Wiring the server into a .NET `IInferenceBackend` / `FallbackInferenceRouter` |
 | [`docs/runtime-tiering-research.md`](docs/runtime-tiering-research.md) | Research note behind [ADR-006](adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md) — runtime reassessment, on-host bake-off, and tier selection |
 | [`omlx-setup-prompt.md`](omlx-setup-prompt.md) | Historical source prompt only — not a source of truth |
 
-## Upgrading from a single-model (ADR-004) install
+## Upgrading from the three-tier (ADR-006) install
 
-If you previously provisioned the single-model (ADR-004) lineup, just re-run the script — it is an in-place, non-destructive upgrade:
+If you previously provisioned the three-tier lineup, just re-run the script — it is an in-place, non-destructive upgrade:
 
 ```bash
 git pull
-./setup-omlx-m5.sh --download-model   # fetches only the 2 new tiers; the existing 30B is skipped
-./setup-omlx-m5.sh --validate         # confirms all three aliases resolve
+./setup-omlx-m5.sh            # GLM is already on disk from T2 — no download needed
+./setup-omlx-m5.sh --validate # confirms coding-workhorse resolves and retired tiers are unpinned
 ```
 
-The re-run detects the existing `coding-fast` model + pin, downloads only the missing `coding-balanced`/`coding-quality` tiers, and applies the new aliases/pins via the admin API (it briefly starts the server, then stops it). It never overwrites your API key, the oMLX-managed `model_settings.json` (it merges via the admin API), or a non-empty Pi config (a merge snippet is left at `~/.omlx/pi-provider-snippet.json`). Running it twice is a no-op.
+The re-run re-renders the start wrapper with the new serving flags (`--hot-cache-max-size 24GB`, `--max-concurrent-requests 10`), renames GLM's alias from `coding-balanced` to `coding-workhorse`, and **actively unpins the retired tiers** (Qwen3-Coder-30B, Qwen3-Coder-Next) via the admin API so their ~30–45 GB is actually freed — the models stay on disk (Qwen3-Coder-30B is the documented inactive fallback; delete Qwen3-Coder-Next by hand if you want the disk back). If the server is running when you re-run, the wrapper update stops it (restart with `omlxctl start`). It never overwrites your API key, the oMLX-managed `model_settings.json` (it merges via the admin API), or a non-empty Pi config (a merge snippet is left at `~/.omlx/pi-provider-snippet.json` — note the provider now exposes only `coding-workhorse`). Running it twice is a no-op.
 
 ## Teardown
 
@@ -110,8 +108,9 @@ sudo launchctl bootout system/com.local.iogpu-wired-limit 2>/dev/null || true
 sudo rm -f /Library/LaunchDaemons/com.local.iogpu-wired-limit.plist
 brew uninstall omlx && brew untap jundot/omlx
 rm -rf ~/.omlx \
-  ~/models/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit \
-  ~/models/GLM-4.7-Flash-8bit \
+  ~/models/GLM-4.7-Flash-8bit                       # the workhorse
+# Also remove whichever retired ADR-006 tiers are still on disk:
+rm -rf ~/models/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit \
   ~/models/Qwen3-Coder-Next-MLX-4bit
 ```
 

--- a/adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md
+++ b/adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md
@@ -1,6 +1,6 @@
 # ADR-006: Restore a multi-tier lineup — two co-resident pinned tiers + one on-demand max tier, staying on oMLX
 
-- Status: accepted
+- Status: superseded by [ADR-009](009-mac-single-workhorse-cloud-frontier.md)
 - Date: 2026-06-24
 
 Supersedes [ADR-004](004-single-text-only-model-no-override.md) for the model

--- a/adrs/008-cross-host-routing-integration.md
+++ b/adrs/008-cross-host-routing-integration.md
@@ -1,6 +1,6 @@
 # ADR-008: Integrate the AMD vLLM appliance as a co-equal peer backend — AMD-first for `coding-fast`
 
-- Status: accepted
+- Status: superseded by [ADR-009](009-mac-single-workhorse-cloud-frontier.md)
 - Date: 2026-06-28
 
 Extends [ADR-006](006-multi-tier-coresident-lineup-stay-on-omlx.md), which

--- a/adrs/009-mac-single-workhorse-cloud-frontier.md
+++ b/adrs/009-mac-single-workhorse-cloud-frontier.md
@@ -1,14 +1,13 @@
 # ADR-009: Mac as a single-model subagent workhorse, with the cloud as the frontier
 
-- Status: accepted (forward direction — not yet implemented; tracked in [#14](https://github.com/psmfd/local-llm/issues/14))
-- Date: 2026-06-29
+- Status: accepted
+- Date: 2026-06-29 (implemented 2026-07-02, [#14](https://github.com/psmfd/local-llm/issues/14))
 
-This ADR is **additive and supersedes nothing** (see "Relationship to prior ADRs"
-below). [ADR-006](006-multi-tier-coresident-lineup-stay-on-omlx.md) (three-tier
+Supersedes [ADR-006](006-multi-tier-coresident-lineup-stay-on-omlx.md) (three-tier
 co-resident lineup) and [ADR-008](008-cross-host-routing-integration.md)
-(cross-host AMD routing) remain the record of the currently-implemented state;
-this ADR records a forward direction whose implementation is tracked in
-[#14](https://github.com/psmfd/local-llm/issues/14).
+(cross-host AMD routing) — see "Relationship to prior ADRs" below. Originally
+recorded as an additive forward direction; the supersession became formal when
+the implementation landed via [#14](https://github.com/psmfd/local-llm/issues/14).
 
 ## Context and Problem Statement
 
@@ -136,23 +135,29 @@ this ADR.
     modest.
   - GLM-4.7-Flash's quality figure (59.2% SWE-bench) is weakly sourced; output
     precision on real orchestrator prompts is still to be confirmed in use.
-  - Deferring formal supersession leaves ADR-006/008 co-existing with this record
-    until #14 lands; the intent-vs-implementation split must be read carefully in
-    the interim.
+  - Formal supersession of ADR-006/008 was deferred until the #14 implementation
+    landed (2026-07-02); during the interim the intent-vs-implementation split had
+    to be read carefully.
 
-## Relationship to prior ADRs (additive — supersedes nothing)
+## Relationship to prior ADRs
 
-This ADR is recorded as a **forward direction**, not a supersession. ADR-006
-(three-tier lineup) and ADR-008 (cross-host AMD routing) are left **untouched and
-remain the record of the currently-implemented state** until the gates above pass
-and `setup-omlx-m5.sh` is reworked (#14). The intended end-state this ADR adopts:
+This ADR **supersedes [ADR-006](006-multi-tier-coresident-lineup-stay-on-omlx.md)**
+(three-tier lineup) **and [ADR-008](008-cross-host-routing-integration.md)**
+(cross-host AMD routing):
 
 - the **Mac single-workhorse absorbs the local executor / `coding-fast` role**,
-- the **AMD appliance (ADR-008) is repurposed or deprecated**, and
+- the **AMD appliance (ADR-008) is repurposed or deprecated** (its hardware was
+  never built; the cross-host design is shelved with it), and
 - the **cloud provider becomes the frontier / quality tier** in the
   `FallbackInferenceRouter`.
 
-Formal supersession of ADR-006/008 is **deferred to the implementation PR (#14)**
-so the record does not assert a teardown ahead of the validated change. Until
-then, a reader should treat ADR-009 as the current *intent* and ADR-006/008 as
-the current *implementation*.
+ADR-002's `--memory-guard-gb 90` / 96 GB wired limit and ADR-001's oMLX runtime
+choice carry forward unchanged, as they did through ADR-006. ADR-005's on-demand
+lifecycle remains in force.
+
+Historical note: this ADR was originally recorded (2026-06-29) as an *additive
+forward direction* that deliberately superseded nothing, so the record would not
+assert a teardown ahead of the validated change. The supersession became formal
+when the implementation — the `setup-omlx-m5.sh` single-model rework and full doc
+sync — landed via [#14](https://github.com/psmfd/local-llm/issues/14) on
+2026-07-02.

--- a/docs/router-wiring.md
+++ b/docs/router-wiring.md
@@ -1,29 +1,20 @@
 # Wiring oMLX into the .NET `IInferenceBackend` / `FallbackInferenceRouter`
 
 This note shows how to register the local oMLX server as one `IInferenceBackend`
-behind your `FallbackInferenceRouter`, routing the three local tiers
-(`coding-fast`, `coding-balanced`, `coding-quality`) → oMLX and falling through to
-a remote backend on failure or saturation.
-
-> **Forward direction — [ADR-009](../adrs/009-mac-single-workhorse-cloud-frontier.md)
-> (additive, pending implementation #14).** A reframe collapses the Mac to a
-> *single* GLM-4.7-Flash workhorse (local executor) with the **cloud as the
-> frontier/quality tier** and the AMD peer repurposed. See
-> [ADR-009 forward direction](#adr-009-forward-direction-single-workhorse-cloud-frontier)
-> below; the ADR-006/008 multi-tier wiring described first remains the implemented
-> state until #14 lands.
+behind your `FallbackInferenceRouter`, routing the executor roles to the single
+local **workhorse** (`coding-workhorse`, [ADR-009](../adrs/009-mac-single-workhorse-cloud-frontier.md))
+and the quality role to a **cloud frontier** backend.
 
 - **Endpoint:** `http://localhost:8000/v1` (OpenAI-style `POST /v1/chat/completions`).
   oMLX also serves Anthropic-style `POST /v1/messages`; this note uses the
   OpenAI chat-completions shape.
 - **Auth:** bearer key read once at startup from `OMLX_API_KEY`, else from the
   0600 file `~/.omlx/api-key`. **Never hardcode the key.**
-- **Aliases:** the `model` field carries the oMLX alias. This host serves three
-  tiers ([ADR-006](../adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md)):
-  `coding-fast` + `coding-balanced` are pinned co-resident; `coding-quality` is the
-  **on-demand** max tier (Qwen3-Coder-Next, lazy-loaded ~16 s on first request).
-  Keep a remote backend as the fallback after the local tiers. Aliases/pins are
-  applied by `setup-omlx-m5.sh` via the admin API.
+- **Aliases:** the `model` field carries the oMLX alias. This host serves one
+  pinned model ([ADR-009](../adrs/009-mac-single-workhorse-cloud-frontier.md)):
+  `coding-workhorse` (GLM-4.7-Flash-8bit, sole resident). The high-fidelity
+  quality role is **not served locally** — it routes to the cloud frontier.
+  The alias/pin is applied by `setup-omlx-m5.sh` via the admin API.
 - **Concurrency:** typed `HttpClient` via `IHttpClientFactory` +
   `AddStandardResilienceHandler` so a local hiccup degrades into the fallback
   router rather than throwing.
@@ -39,7 +30,9 @@ a remote backend on failure or saturation.
 ```csharp
 public enum ModelRole { Fast, Balanced, Quality }
 public sealed record ChatMessage(string Role, string Content);
-public sealed record InferenceRequest(ModelRole Role, IReadOnlyList<ChatMessage> Messages, float? Temperature = null);
+// MaxTokens: tool-bearing requests against the workhorse need >= ~200 (GLM emits
+// a reasoning preamble before the tool call — ADR-009); expose it end-to-end.
+public sealed record InferenceRequest(ModelRole Role, IReadOnlyList<ChatMessage> Messages, float? Temperature = null, int? MaxTokens = null);
 public sealed record InferenceResponse(string Content, bool IsAvailable);
 
 public sealed class InferenceUnavailableException(string message, Exception? inner = null)
@@ -105,19 +98,21 @@ internal sealed record OmlxMessage([property: JsonPropertyName("role")] string R
                                    [property: JsonPropertyName("content")] string Content);
 internal sealed record OmlxChatRequest([property: JsonPropertyName("model")] string Model,
                                        [property: JsonPropertyName("messages")] IReadOnlyList<OmlxMessage> Messages,
-                                       [property: JsonPropertyName("temperature"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] float? Temperature);
+                                       [property: JsonPropertyName("temperature"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] float? Temperature,
+                                       [property: JsonPropertyName("max_tokens"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] int? MaxTokens);
 internal sealed record OmlxChoice([property: JsonPropertyName("message")] OmlxMessage Message);
 internal sealed record OmlxChatResponse([property: JsonPropertyName("choices")] IReadOnlyList<OmlxChoice> Choices);
 
 public sealed class OmlxInferenceBackend(HttpClient httpClient, ILogger<OmlxInferenceBackend> logger)
     : IInferenceBackend
 {
-    // Logical role → oMLX model alias (the "model" field).
+    // Logical role → oMLX model alias (the "model" field). Executor roles all
+    // map to the single pinned workhorse (ADR-009). Quality is deliberately
+    // ABSENT: the role must fall through to the cloud frontier backend.
     private static readonly Dictionary<ModelRole, string> ModelAliases = new()
     {
-        [ModelRole.Fast]     = "coding-fast",
-        [ModelRole.Balanced] = "coding-balanced",
-        [ModelRole.Quality]  = "coding-quality",   // on-demand: first call lazy-loads (~16 s)
+        [ModelRole.Fast]     = "coding-workhorse",   // single GLM-4.7-Flash alias
+        [ModelRole.Balanced] = "coding-workhorse",
     };
 
     // No global DefaultIgnoreCondition: the property-level [JsonIgnore] on the
@@ -129,13 +124,17 @@ public sealed class OmlxInferenceBackend(HttpClient httpClient, ILogger<OmlxInfe
 
     public async Task<InferenceResponse> CompleteAsync(InferenceRequest request, CancellationToken ct = default)
     {
+        // A role this backend does not serve (Quality) must throw
+        // InferenceUnavailableException — NOT ArgumentOutOfRangeException — or the
+        // FallbackInferenceRouter never advances to the cloud frontier backend.
         if (!ModelAliases.TryGetValue(request.Role, out string? alias))
-            throw new ArgumentOutOfRangeException(nameof(request), request.Role, "No oMLX alias for role.");
+            throw new InferenceUnavailableException($"oMLX does not serve the {request.Role} role.");
 
         var wire = new OmlxChatRequest(
             alias,
             request.Messages.Select(m => new OmlxMessage(m.Role, m.Content)).ToList(),
-            request.Temperature);
+            request.Temperature,
+            request.MaxTokens);
 
         try
         {
@@ -226,9 +225,10 @@ builder.Services.AddHttpClient<OmlxInferenceBackend>((sp, client) =>
 builder.Services.AddTransient<IInferenceBackend>(
     static sp => sp.GetRequiredService<OmlxInferenceBackend>());
 
-// 3. Other backends follow the same concrete-client + transient-bridge pattern:
-// builder.Services.AddHttpClient<RemoteAnthropicBackend>(/* ... */).AddStandardResilienceHandler(/* ... */);
-// builder.Services.AddTransient<IInferenceBackend>(static sp => sp.GetRequiredService<RemoteAnthropicBackend>());
+// 3. The cloud frontier backend (serves the Quality role; also the fallback for
+//    the executor roles) follows the same concrete-client + transient-bridge pattern:
+// builder.Services.AddHttpClient<CloudFrontierBackend>(/* ... */).AddStandardResilienceHandler(/* ... */);
+// builder.Services.AddTransient<IInferenceBackend>(static sp => sp.GetRequiredService<CloudFrontierBackend>());
 
 // 4. The router consumes IEnumerable<IInferenceBackend>. Register it Transient (or
 //    Scoped) — never Singleton, or it captures the transient backends and defeats
@@ -236,94 +236,46 @@ builder.Services.AddTransient<IInferenceBackend>(
 builder.Services.AddTransient<FallbackInferenceRouter>();
 ```
 
-## Router ordering
+## Router ordering (ADR-009)
 
-> **Revised by [ADR-008](../adrs/008-cross-host-routing-integration.md) for the
-> two-host topology** — see [Cross-host topology](#cross-host-topology-adr-008) below.
-> With the AMD peer present, the AMD backend registers *first* and serves
-> `coding-fast` only; oMLX serves `coding-balanced`/`coding-quality` and is the
-> fast-role fallback. The single-host narrative here still describes the oMLX side.
-
-- **Order = priority.** Register oMLX first; the router iterates registration
-  order, so the local backend is primary for every role. It catches
+- **Order = priority.** Register oMLX first, the cloud frontier backend second;
+  the router iterates registration order. It catches
   `InferenceUnavailableException` and advances to the next backend.
-- **Role routing.** All three roles map through the alias dictionary to local oMLX
-  tiers (ADR-006). `coding-fast` and `coding-balanced` are pinned co-resident, so
-  they answer immediately. `coding-quality` (Qwen3-Coder-Next) is **on-demand**:
-  oMLX lazy-loads it on the first request (~16 s), so that call is slow — size the
-  resilience `AttemptTimeout` to tolerate it, or pre-warm with a throwaway request.
-  If a tier ever errors (e.g. transient load failure) it is wrapped as
-  `InferenceUnavailableException` → fallback to the next backend.
-- **Saturation.** oMLX runs at `--max-concurrent-requests 16`; a 429 trips the
-  circuit breaker, diverting traffic to the remote backend until it recovers.
+- **Role routing.** `Fast` / `Balanced` → **Mac oMLX workhorse** primary → cloud
+  fallback. `Quality` → oMLX throws `InferenceUnavailableException` (no local
+  quality tier — the alias dictionary omits the role) → **cloud frontier**.
+- **Saturation.** oMLX runs at `--max-concurrent-requests 10` (**"The Mark"**,
+  validated on-host; the safe ceiling falls as shared-prefix context grows —
+  clean to N≥15 @ ~9K ctx but 10 @ ~16K, so keep subagent prefixes modest).
+  A 429 or a memory-guard 500 trips the circuit breaker, diverting traffic to
+  the cloud frontier until the local server recovers.
+- **max_tokens.** GLM-4.7-Flash emits a **reasoning preamble before tool calls**;
+  set `InferenceRequest.MaxTokens` ≥ ~200 on tool-bearing requests so the call is
+  not truncated, and keep `AttemptTimeout` generous (no cold-load tier anymore,
+  but decode + preamble still take time).
 
-## Cross-host topology (ADR-008)
-
-With the always-on **AMD vLLM appliance** added as a second endpoint, the router is
-no longer single-host. Register the AMD backend **first** and the Mac oMLX backend
-second:
-
-- `coding-fast` → **AMD vLLM** primary; on `InferenceUnavailableException` →
-  **Mac oMLX T1** (still co-resident, zero-swap) → cloud.
-- `coding-balanced` → AMD throws `InferenceUnavailableException` (it serves only
-  `coding-fast`) → **Mac oMLX T2** → cloud.
-- `coding-quality` → AMD can't fit the ~45 GB max tier → **Mac oMLX** on-demand → cloud.
-
-The AMD backend's alias dictionary contains only `coding-fast`; every other role
-throws `InferenceUnavailableException` so the chain advances — which is why **both**
-backends must throw that exception type (not `ArgumentOutOfRangeException`) for
-unserved roles. See [ADR-008](../adrs/008-cross-host-routing-integration.md).
-
-## ADR-009 forward direction: single workhorse, cloud frontier
-
-[ADR-009](../adrs/009-mac-single-workhorse-cloud-frontier.md) is **additive and not
-yet implemented** (tracked in #14); the wiring above stays in force until then. The
-forward target:
-
-- **Local Mac = one pinned GLM-4.7-Flash workhorse** serving the executor roles;
-  the AMD peer (ADR-008) is repurposed/deprecated.
-- **Cloud = the frontier**: the high-fidelity `coding-quality` role routes to a
-  cloud backend, not a local tier.
-
-Collapse the three local aliases to one workhorse model, and let the quality role
-fall through to the cloud frontier backend:
-
-```csharp
-// oMLX workhorse backend: executor roles all map to the single pinned model.
-private static readonly Dictionary<ModelRole, string> ModelAliases = new()
-{
-    [ModelRole.Fast]     = "coding-workhorse",   // single GLM-4.7-Flash alias
-    [ModelRole.Balanced] = "coding-workhorse",
-    // Quality is NOT served locally — omit it so the role throws
-    // InferenceUnavailableException and the chain advances to the cloud frontier.
-};
-```
-
-Router ordering under ADR-009:
-
-- `coding-fast` / `coding-balanced` → **Mac oMLX workhorse** primary → cloud fallback.
-- `coding-quality` → Mac throws `InferenceUnavailableException` (no local quality
-  tier) → **cloud frontier** backend (registered for the quality role).
-
-Serving/resilience notes specific to the workhorse:
-
-- oMLX runs `--max-concurrent-requests 10` (**"The Mark"**, validated on-host; the
-  safe ceiling falls as shared-prefix context grows — clean to N≥15 @ ~9K ctx but
-  10 @ ~16K, so keep subagent prefixes modest). A 429 or a memory-guard 500 trips
-  the circuit breaker → cloud.
-- GLM-4.7-Flash emits a **reasoning preamble before tool calls**; keep `max_tokens`
-  ≥ ~200 on tool-bearing requests so the call is not truncated, and keep
-  `AttemptTimeout` generous (no ~16 s cold-load tier anymore, but decode + preamble
-  still take time).
+> **Historical note.** Earlier revisions of this doc described the ADR-006
+> three-tier wiring (`coding-fast`/`coding-balanced`/`coding-quality` all local)
+> and the ADR-008 two-host AMD topology. Both ADRs are superseded by
+> [ADR-009](../adrs/009-mac-single-workhorse-cloud-frontier.md); see git history
+> for the retired wiring.
 
 ## Tool-call schema-validate-and-retry guard
 
 A small local workhorse occasionally emits a malformed tool call (invalid JSON
 arguments) or — if `max_tokens` is too low — truncates before completing it. A
 single malformed call breaks an agent pipeline silently. Wrap tool-bearing
-completions in a validate-and-retry loop at the dispatcher: parse the call,
-validate its arguments against the tool's JSON schema, and on failure re-issue once
-with a structured corrective message before falling through.
+completions in a validate-and-retry loop: parse the call, validate its arguments
+against the tool's JSON schema, and on failure re-issue once with a structured
+corrective message before falling through.
+
+**This guard wraps a single `IInferenceBackend` (the workhorse), not the
+`FallbackInferenceRouter`.** Implement it as a method on (or decorator around)
+`OmlxInferenceBackend`, so the corrective retry re-targets the same local model.
+Wrapped around the router instead, the first failure could already have failed
+over to the cloud backend, and the "retry" would never re-exercise the workhorse.
+The terminal `InferenceUnavailableException` is what hands the request to the
+router's next backend.
 
 ```csharp
 // Sketch — assumes the backend surfaces tool_calls and you hold the tool's

--- a/docs/workhorse-probes.md
+++ b/docs/workhorse-probes.md
@@ -1,0 +1,79 @@
+# Workhorse probes — one-time on-host checks before trusting the config
+
+Two short probes to run once on the M5 Max after provisioning (and again after
+any oMLX or model update), closing the residual risks the ADR-009 review
+flagged. Neither is part of `--validate` — both need a long prompt or a
+model-behavior judgement that the scripted checks deliberately avoid.
+
+Prereqs: server provisioned, `omlxctl start` done, `KEY="$(cat ~/.omlx/api-key)"`.
+
+## 1. Long-context MLA-compression probe (≥16K tokens)
+
+**Why.** GLM-4.7-Flash uses MLA KV compression, and at least one engine (vLLM)
+has shipped a silent MLA→MHA fallback for exactly this model — a ~16–17× KV
+blowup that surfaced mostly at long contexts. The ADR-009 acceptance probe ran
+at ~7.3K tokens; this re-check covers the 9–16K range the fan-out actually uses
+("The Mark" was measured at ~16K).
+
+**Procedure.**
+
+1. Note the resting footprint with the model loaded but idle:
+
+   ```bash
+   omlxctl status
+   vmmap --summary "$(pgrep -f 'omlx serve')" | grep -i 'physical footprint'
+   ```
+
+2. Send one completion with a ≥16K-token prompt (any large file dump works —
+   `PROMPT` below just needs to be ~60–70 KB of text):
+
+   ```bash
+   PROMPT="$(head -c 70000 /usr/share/dict/words | tr '\n' ' ')"
+   curl -sS -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
+     -d "$(jq -n --arg p "$PROMPT" '{model:"coding-workhorse",max_tokens:256,messages:[{role:"user",content:$p}]}')" \
+     http://localhost:8000/v1/chat/completions >/dev/null
+   ```
+
+3. Re-measure the footprint during/immediately after decode.
+
+**Pass:** the KV growth for a ~16K prompt stays in the hundreds-of-MB range
+(MLA ≈ GQA class — the ADR-009 7.3K probe measured +214 MB). **Fail:** growth in
+the multi-GB range for one request → suspect an MHA fallback; do not raise
+concurrency, and re-verify the oMLX/mlx-lm version against the GLM MLA support
+matrix before continuing.
+
+## 2. `enable_thinking` pass-through probe
+
+**Why.** GLM emits a reasoning preamble before every answer/tool call — the
+reason `max_tokens ≥ ~200` is required on tool-bearing requests. GLM's chat
+template supports `chat_template_kwargs: {"enable_thinking": false}` on several
+engines; if oMLX passes it through, the preamble token tax disappears at the
+source. Untested on oMLX — and note SGLang has an open issue where GLM's
+reasoning could not be fully disabled, so verify the behavior, don't assume it.
+
+**Procedure.**
+
+```bash
+curl -sS -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
+  -d '{"model":"coding-workhorse","max_tokens":256,
+       "chat_template_kwargs":{"enable_thinking":false},
+       "messages":[{"role":"user","content":"Reply with the single word: pong"}]}' \
+  http://localhost:8000/v1/chat/completions
+```
+
+Compare `usage.completion_tokens` with and without the
+`chat_template_kwargs` field, and check whether the content still carries a
+reasoning preamble.
+
+**If it works:** the orchestrator can send `enable_thinking:false` on
+tool-bearing requests instead of relying only on generous `max_tokens` (keep
+`max_tokens ≥ 200` anyway as the belt-and-suspenders floor). **If oMLX rejects
+or ignores the field:** stick with the `max_tokens` floor; re-test after oMLX
+upgrades.
+
+## Recording results
+
+Note the outcome (date, oMLX version, pass/fail, measured numbers) in the PR or
+issue that prompted the re-run. If probe 1 fails, that is grounds to revisit
+ADR-009's model choice — the on-disk Qwen3-Coder-30B fallback (GQA,
+prefix-cache-safe, tool-clean) is the documented escape hatch.

--- a/macos/local-llm-mac-os-creation.md
+++ b/macos/local-llm-mac-os-creation.md
@@ -1,9 +1,10 @@
 # Task: provision oMLX for local coding inference on an M5 Max
 
 > **Status:** authoritative implementation brief. Durable decisions live in
-> `CLAUDE.md` and `adrs/003-vlm-engine-workaround-lineup.md` (superseding
-> `adrs/002-qwen36-lineup-memory-guard.md` and, through it,
-> `adrs/001-local-mlx-inference-omlx.md`); executable behavior
+> `CLAUDE.md` and `adrs/009-mac-single-workhorse-cloud-frontier.md` (superseding
+> `adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md` and
+> `adrs/008-cross-host-routing-integration.md`; the guard/wired-limit from
+> `adrs/002` and the runtime from `adrs/001` carry forward); executable behavior
 > lives in `setup-omlx-m5.sh` and `templates/`; downstream integration guidance
 > lives in `docs/router-wiring.md`. The top-level `omlx-setup-prompt.md` is a
 > historical source prompt, not an additional source of truth.
@@ -23,22 +24,19 @@ The implementing agent follows its standard operating framework: classify the ta
 These came out of prior analysis. Treat the runtime and serving config as decided; **re-verify the model choice and exact HuggingFace MLX repo IDs against current availability** as of today before downloading anything — search, confirm the repo exists, and confirm it still represents the best local coding model for this hardware. If something better has shipped, propose it in the plan rather than silently substituting.
 
 - **Runtime:** oMLX, installed via Homebrew (`brew tap jundot/omlx https://github.com/jundot/omlx && brew install omlx`).
-- **Model tiers (ADR-006):** three verified text-only coder builds (no `vision_config` → batched LLM engine, no override), tool-call-verified on oMLX:
-  - **T1 `coding-fast`** — `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` (`Qwen3MoeForCausalLM`, MoE ~3B active, 262K ctx), ~30.6 GB. **Pinned, co-resident.**
-  - **T2 `coding-balanced`** — `mlx-community/GLM-4.7-Flash-8bit` (`Glm4MoeLiteForCausalLM`, MoE ~3B active, 202K ctx), ~30 GB. **Pinned, co-resident.**
-  - **MAX `coding-quality`** — `lmstudio-community/Qwen3-Coder-Next-MLX-4bit` (`Qwen3NextForCausalLM`, 80B/~3B active, ~71% SWE-bench), ~45 GB. **On-demand** (lazy-loads ~16 s on first request, idle-evicts; not pinned — it does not co-reside with T1+T2). The earlier multimodal Qwen3.6 primary + `model_type_override` approach (ADR-003) was retired: every Qwen3.6 build is VLM-trapped and no runtime change unlocks a better *coder* (ADR-006, `docs/runtime-tiering-research.md`).
-- **Serving flags:** `--host 127.0.0.1` (explicit loopback pin), port `8000`, `--memory-guard-gb 90` (replaces the removed `--max-process-memory`), `--paged-ssd-cache-dir ~/.omlx/cache`, `--hot-cache-max-size 18GB` (absolute size only — oMLX rejects percentages), `--max-concurrent-requests 16`, `--api-key` from the 0600 file.
-- **Metal wired limit:** raise `iogpu.wired_limit_mb` to ~96 GB (98304) so Metal can wire the two co-resident tiers (~60 GB) with KV headroom; persist across reboot via a LaunchDaemon (needs sudo).
+- **Model (single workhorse, ADR-009):** **`coding-workhorse`** — `mlx-community/GLM-4.7-Flash-8bit` (`Glm4MoeLiteForCausalLM`, MoE ~3B active, 202K ctx, MLA KV compression), ~30 GB. **Pinned, sole resident model.** A verified text-only coder build (no `vision_config` → batched LLM engine, no override), tool-call-verified on oMLX. High-fidelity work routes to the **cloud frontier**, not a local tier. Retired ADR-006 tiers (`Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` — kept on disk as the inactive fallback — and `Qwen3-Coder-Next-MLX-4bit`) are never downloaded or served; setup unpins them if a prior install left them pinned.
+- **Serving flags:** `--host 127.0.0.1` (explicit loopback pin), port `8000`, `--memory-guard-gb 90` (replaces the removed `--max-process-memory`), `--paged-ssd-cache-dir ~/.omlx/cache`, `--hot-cache-max-size 24GB` (oMLX accepts absolute sizes and percentages; an absolute value is pinned for a deterministic footprint), `--max-concurrent-requests 10` (ADR-009 "The Mark" — prefill-activation-bound, measured 10 clean @ ~16K ctx), `--api-key` from the 0600 file.
+- **Metal wired limit:** raise `iogpu.wired_limit_mb` to ~96 GB (98304) so Metal can wire the workhorse (~30 GB) with maximal KV/prefix-cache headroom; persist across reboot via a LaunchDaemon (needs sudo).
 - **On-demand lifecycle (no login autostart):** per-user LaunchAgent running a start wrapper (brew services only starts with zero-config defaults, so use a wrapper that carries the tuned flags). The agent is `RunAtLoad=false` + `KeepAlive=false` — registered at login but never started, and a stop/crash stays down. Start/stop is intentional via the installed `omlxctl` tool (ADR-005).
 
 ## What to do
 
-1. **Verify environment** — macOS, arm64, RAM ≥ ~120 GB, free disk ≥ ~140 GB (three tiers ≈ 105 GB + cache), Homebrew present. Abort with exit 2 on those hard precondition failures. Treat M5 Max as the tuned target; warn rather than hard-fail on non-M5 Apple Silicon so nearby Max-class hosts can smoke-test deliberately.
+1. **Verify environment** — macOS, arm64, RAM ≥ ~120 GB, free disk ≥ ~60 GB (workhorse ≈ 30 GB + staging/cache), Homebrew present. Abort with exit 2 on those hard precondition failures. Treat M5 Max as the tuned target; warn rather than hard-fail on non-M5 Apple Silicon so nearby Max-class hosts can smoke-test deliberately.
 2. **Author or reuse the setup script.** If `setup-omlx-m5.sh` already exists in the working directory, review it against the spec above and the conventions, then use it. Otherwise write it. It must: install oMLX (no MCP extra); create `~/models`, `~/.omlx/cache`, `~/.omlx/logs`; generate the 0600 API key; set + persist the wired limit; write the start wrapper; install the on-demand LaunchAgent (RunAtLoad=false) and the `omlxctl` control tool, leaving the server stopped; leave model download opt-in (default off) routing to the `/admin` downloader unless repo IDs are verified.
 3. **Lint it.** Run `shellcheck` and fix all Error/Warning findings; report results in the structured review format with a verdict line.
 4. **Run it**, supplying sudo when prompted for the wired-limit step.
-5. **Acquire the models.** Once you've verified the exact repo IDs, download the three tiers into `~/models` (via `hf download`), skipping any already present. Confirm they load.
-6. **Pin + alias the tiers** via the oMLX admin API (`apply_pins`: briefly start the server, PUT each tier's `model_alias`/`is_pinned` — T1+T2 pinned, MAX on-demand — then stop it; `model_settings.json` is oMLX-owned so never write it directly). Degrade to printed manual `/admin` steps if the API can't be reached.
+5. **Acquire the model.** Once you've verified the exact repo ID, download the workhorse into `~/models` (via `hf download`), skipping it if already present. Confirm it loads.
+6. **Pin + alias the workhorse** via the oMLX admin API (`apply_pins`: briefly start the server, PUT the model's `model_alias`/`is_pinned` — and clear `is_pinned` on any retired ADR-006 tier still registered — then stop it; `model_settings.json` is oMLX-owned so never write it directly). Degrade to printed manual `/admin` steps if the API can't be reached.
 7. **Validate the endpoint** — `curl` `http://localhost:8000/v1/models` with the API key, then a small `/v1/chat/completions` call, and a **tool-calling** call to confirm the model emits well-formed `tool_call` markup (the orchestrator depends on this; flag if the parser needs configuration).
 
 ## Deliverables
@@ -46,7 +44,7 @@ These came out of prior analysis. Treat the runtime and serving config as decide
 - A working, pinned oMLX server reachable at `http://localhost:8000/v1` (and `/v1/messages` for Anthropic-style clients).
 - The reviewed, shellcheck-clean setup script.
 - An **ADR** (MADR minimal, in `adrs/`) recording the local-inference convention: runtime choice, model choice with the bandwidth/MoE rationale, and the serving config.
-- A note on wiring the downstream `IInferenceBackend` / `FallbackInferenceRouter` endpoint to this server (route `coding-fast`/`coding-balanced` → co-resident tiers; `coding-quality` → on-demand max tier, remote as fallback).
+- A note on wiring the downstream `IInferenceBackend` / `FallbackInferenceRouter` endpoint to this server (route fast/balanced roles → `coding-workhorse`; the quality role → the cloud frontier provider).
 - An efficacy report.
 
 Stop and show the operator the plan before executing anything that writes, installs, or runs.

--- a/setup-omlx-m5.sh
+++ b/setup-omlx-m5.sh
@@ -12,9 +12,11 @@
 #   ./setup-omlx-m5.sh [options]
 #
 # Options:
-#   --download-model   Download the three model tiers (~105 GB total) via
-#                      `hf download`. Off by default. Existing models are skipped,
-#                      so this is safe to re-run when upgrading.
+#   --download-model   Download the coding-workhorse model (~30 GB) via
+#                      `hf download`. Off by default. Retired ADR-006 tiers are
+#                      never downloaded. Existing model dirs are skipped (never
+#                      re-downloaded or deleted), so this is safe to re-run when
+#                      upgrading.
 #   --configure-pi     Register the oMLX provider with the Pi coding agent.
 #                      Auto-writes ~/.pi/agent/models.json ONLY when its
 #                      providers object is empty (backup taken first);
@@ -78,40 +80,59 @@ WIRED_LIMIT_MB=98304    # 96 GB; leaves ~32 GB for macOS on a 128 GB host (ADR-0
 WIRED_MIN_MB=90000      # wrapper warns below this
 
 MIN_RAM_GB=120
-MIN_DISK_GB=140         # T1+T2 (~60 GB) + on-demand MAX (~45 GB) + paged-SSD cache headroom (ADR-006)
+MIN_DISK_GB=60          # GLM-4.7-Flash-8bit (~30 GB) + hf staging/logs headroom (ADR-009).
+                        # Gates required FREE space only — retired ADR-006 tiers
+                        # already on disk are sunk cost, not part of this floor.
 
-# --- Model tiers (ADR-006) --------------------------------------------------
-# Three tiers, all verified TEXT-ONLY MLX coder builds (no vision_config → batched
-# LLM engine, concurrency-safe, no engine override) and tool-call-verified on oMLX:
-#   T1  coding-fast     Qwen3-Coder-30B-A3B-8bit   (~30.6 GB)  PINNED, co-resident
-#   T2  coding-balanced GLM-4.7-Flash-8bit         (~30 GB)    PINNED, co-resident
-#   MAX coding-quality  Qwen3-Coder-Next-4bit      (~45 GB)    on-demand (lazy-load, NOT pinned)
-# T1+T2 stay co-resident under the 96 GB wired ceiling with KV headroom; MAX is
-# lazy-loaded on first request and TTL-evicts when idle (never co-resident — it
-# does not fit alongside T1+T2). Repo IDs verified against HuggingFace config.json
-# on 2026-06-24; re-probed before each download. Confirm the best current models
-# before large downloads. See docs/runtime-tiering-research.md.
+# --- Model lineup (ADR-009: single Mac workhorse, cloud is the frontier) -----
+# ADR-006's three co-resident/on-demand tiers are retired: the cloud provider is
+# now the quality frontier and the Mac's only job is to serve a homogeneous
+# subagent fan-out from ONE pinned model, maximizing shared prefix-cache reuse
+# and KV headroom (~60 GB vs ADR-006's ~29 GB under the 90 GB guard). The model
+# is a verified TEXT-ONLY MLX coder build (no vision_config → batched LLM engine,
+# no engine override) and tool-call-verified on oMLX. Repo ID verified against
+# HuggingFace config.json 2026-06-29 (ADR-009); re-probed before download.
+# See adrs/009-mac-single-workhorse-cloud-frontier.md (decision) and
+# docs/runtime-tiering-research.md (model-selection research).
 #
-# Each TIER_MODELS entry is "repo|alias|pinned(true|false)" — order is T1, T2, MAX.
-# Bash-3.2-safe indexed array (macOS default shell).
+# TIER_MODELS holds exactly one entry, "repo|alias|pinned(true|false)", so every
+# existing loop (download, pi-config, pin/alias, validate) works unchanged over a
+# 1-element, Bash-3.2-safe indexed array (macOS default shell).
 TIER_MODELS=(
-    "lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit|coding-fast|true"
-    "mlx-community/GLM-4.7-Flash-8bit|coding-balanced|true"
-    "lmstudio-community/Qwen3-Coder-Next-MLX-4bit|coding-quality|false"
+    "mlx-community/GLM-4.7-Flash-8bit|coding-workhorse|true"
 )
-# T1's alias drives the detailed validation probes below (chat/tool/concurrency).
-PRIMARY_ALIAS="coding-fast"
+# The workhorse's alias drives the detailed validation probes below
+# (chat/tool/concurrency).
+PRIMARY_ALIAS="coding-workhorse"
 
-# Field accessors for a TIER_MODELS entry (split on '|').
+# RETIRED_MODELS: ADR-006 tiers this script no longer downloads, aliases, or
+# validates. Entries stay on disk (never deleted); Qwen3-Coder-30B remains the
+# documented INACTIVE fallback should GLM ever regress (ADR-009). apply_pins
+# actively clears is_pinned/dflash on these — only when they already exist in
+# oMLX's model_settings.json — so an upgraded ADR-006 host actually frees the
+# memory it was holding for them. Format: "repo|old_alias" (2 fields — no pin
+# field; the action is always force-unpin). The old alias is echoed back
+# unchanged in the unpin PUT body rather than cleared, because the admin PUT's
+# replace-vs-merge semantics for omitted fields are unverified; a stale alias on
+# an unpinned model is inert (no configured client requests it).
+RETIRED_MODELS=(
+    "lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit|coding-fast"
+    "lmstudio-community/Qwen3-Coder-Next-MLX-4bit|coding-quality"
+)
+
+# Field accessors for a TIER_MODELS/RETIRED_MODELS entry (split on '|').
+# tier_pin() is only meaningful on TIER_MODELS entries — RETIRED_MODELS entries
+# have no third field; never read a pin flag from them.
 tier_repo()  { printf '%s' "${1%%|*}"; }
 tier_alias() { local r="${1#*|}"; printf '%s' "${r%%|*}"; }
 tier_pin()   { printf '%s' "${1##*|}"; }
 tier_dir()   { printf '%s' "$MODELS_DIR/$(basename "$(tier_repo "$1")")"; }
 
-# Pi coding-agent provider registration (--configure-pi). contextWindow is half
-# the model's 262144-token native context (verified config.json, rope_scaling
-# null): 16 concurrent sessions at full context would overrun the KV/wired budget
-# and collapse prefix-cache reuse (ADR-004).
+# Pi coding-agent provider registration (--configure-pi). contextWindow stays at
+# 131072 — comfortably inside GLM-4.7-Flash's 202K native context while keeping
+# the fan-out honest: safe concurrency is prefill-activation-bound and falls as
+# context grows (ADR-009 "The Mark": 10 @ ~16K ctx), so clients should not be
+# invited to fill the full native window.
 PI_AGENT_DIR="${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}"
 PI_CONTEXT_WINDOW=131072
 PI_MAX_TOKENS=16384
@@ -591,15 +612,16 @@ maybe_download_models() {
             [ -d "$(tier_dir "$entry")" ] && { ((present++)) || true; }
         done
         if [ "$present" -eq 0 ]; then
-            record_warn "model" "download is opt-in and no model is on disk — the server will serve ZERO models until you run: ./setup-omlx-m5.sh --download-model (then pin/alias in /admin)"
+            record_warn "model" "download is opt-in and the workhorse model is not on disk — the server will serve ZERO models until you run: ./setup-omlx-m5.sh --download-model (then pin/alias in /admin)"
         else
-            skip "model" "download is opt-in — ${present} tier(s) already on disk; re-run with --download-model to fetch the rest, or use the /admin downloader"
+            skip "model" "download is opt-in — workhorse model already on disk"
         fi
         return
     fi
-    # All three ADR-006 tiers. download_model() skips any dir that is already
-    # populated, so on an upgrade from a single-model (ADR-004) install only the
-    # missing tiers are fetched.
+    # Only the ADR-009 workhorse is fetched. Retired ADR-006 tiers are never
+    # downloaded (Qwen3-Coder-30B stays on disk as the inactive fallback if a
+    # prior install put it there). download_model() skips a populated dir, so an
+    # upgrade re-run fetches nothing it already has.
     local entry
     for entry in "${TIER_MODELS[@]}"; do
         download_model "$(tier_repo "$entry")" "$(tier_dir "$entry")" "model-$(tier_alias "$entry")"
@@ -615,7 +637,7 @@ maybe_download_models() {
 print_pi_settings_instructions() {
     local settings_file="$1"
     # settings.json is hand-curated and git-tracked; never edited automatically.
-    info "To surface the tiers in Pi's picker, add to the enabledModels array in $settings_file:"
+    info "To surface the workhorse in Pi's picker, add to the enabledModels array in $settings_file:"
     local entry
     for entry in "${TIER_MODELS[@]}"; do
         echo "      \"omlx/$(tier_alias "$entry")\""
@@ -638,18 +660,14 @@ configure_pi_provider() {
     local models_file="$PI_AGENT_DIR/models.json"
     local settings_file="$PI_AGENT_DIR/settings.json"
     local snippet_dest="$OMLX_HOME/pi-provider-snippet.json"
-    # Register the tiers by their oMLX aliases (ADR-006).
-    local t1_id t2_id max_id
-    t1_id="$(tier_alias "${TIER_MODELS[0]}")"
-    t2_id="$(tier_alias "${TIER_MODELS[1]}")"
-    max_id="$(tier_alias "${TIER_MODELS[2]}")"
+    # Register the workhorse by its oMLX alias (ADR-009).
+    local model_id
+    model_id="$(tier_alias "${TIER_MODELS[0]}")"
 
     if render_template "$TEMPLATE_DIR/pi-models-omlx.json" "$snippet_dest" \
         "__PORT__"              "$PORT" \
         "__API_KEY_FILE__"      "$API_KEY_FILE" \
-        "__T1_ID__"             "$t1_id" \
-        "__T2_ID__"             "$t2_id" \
-        "__MAX_ID__"            "$max_id" \
+        "__MODEL_ID__"          "$model_id" \
         "__PI_CONTEXT_WINDOW__" "$PI_CONTEXT_WINDOW" \
         "__PI_MAX_TOKENS__"     "$PI_MAX_TOKENS"; then
         ok "pi-config" "rendered provider snippet: $snippet_dest"
@@ -708,29 +726,61 @@ PYEOF
 
 # --- Pin/alias fallback instructions (when the admin API can't be reached) --
 print_pin_instructions() {
-    # Printed when apply_pins cannot reach the admin API. Lists every tier so the
-    # operator can set aliases + pins manually in the admin panel.
-    info "Apply model aliases + pins manually in the admin panel:"
+    # Printed when apply_pins cannot reach the admin API, so the operator can
+    # set the workhorse alias/pin — and clear any retired ADR-006 pins —
+    # manually in the admin panel.
+    info "Apply the workhorse alias + pin manually in the admin panel:"
     echo "      1. Start the server (omlxctl start), then open http://localhost:${PORT}/admin"
-    echo "      2. Under Models, for each tier set the alias and pin state:"
+    echo "      2. Under Models, set the alias and pin state:"
     local entry
     for entry in "${TIER_MODELS[@]}"; do
-        if [ "$(tier_pin "$entry")" = "true" ]; then
-            echo "         - $(basename "$(tier_repo "$entry")")  alias '$(tier_alias "$entry")'  PIN (keep co-resident)"
-        else
-            echo "         - $(basename "$(tier_repo "$entry")")  alias '$(tier_alias "$entry")'  do NOT pin (on-demand; set idle TTL if desired)"
-        fi
+        echo "         - $(basename "$(tier_repo "$entry")")  alias '$(tier_alias "$entry")'  PIN (sole resident model)"
+    done
+    echo "      3. If upgrading from the ADR-006 three-tier install, also UNPIN the retired tiers"
+    echo "         (leave them on disk — Qwen3-Coder-30B is the documented inactive fallback):"
+    local r
+    for r in "${RETIRED_MODELS[@]}"; do
+        echo "         - $(basename "$(tier_repo "$r")")  UNPIN (clear is_pinned; DFlash off)"
     done
     echo "      Aliases/pins persist in ${OMLX_HOME}/model_settings.json and appear in GET /v1/models."
-    echo "      No engine override is needed — all tiers are text-only coder builds (ADR-006)."
+    echo "      No engine override is needed — the workhorse is a text-only coder build (ADR-009)."
 }
 
-# Idempotency gate: returns 0 if model_settings.json already has every tier's
-# alias and pin state. We only READ the oMLX-owned file here. Lets a re-run skip
-# the whole start/pin/stop cycle (no server churn) — key for upgrade re-runs.
-pins_already_applied() {
+# retired_model_state REPO — reads the LOCAL oMLX-owned model_settings.json
+# (never the server) and prints:
+#   absent  oMLX has never registered this model — no PUT should be sent
+#           (retired tiers are never actively aliased/registered by us)
+#   dirty   present and still is_pinned or dflash_ssd_cache — needs an unpin PUT
+#   clean   present and already unpinned/dflash-off — nothing to do
+# Shared by pins_converged (gate) and apply_pins (action) — one source of truth.
+retired_model_state() {
+    local repo="$1"
+    [ -f "$OMLX_HOME/model_settings.json" ] || { printf 'absent'; return; }
+    python3 - "$OMLX_HOME/model_settings.json" "$(basename "$repo")" <<'PYEOF' 2>/dev/null || printf 'absent'
+import json, sys
+try:
+    models = json.load(open(sys.argv[1])).get("models", {})
+except Exception:
+    print("absent"); sys.exit(0)
+m = models.get(sys.argv[2])
+if not m:
+    print("absent")
+elif bool(m.get("is_pinned")) or bool(m.get("dflash_ssd_cache")):
+    print("dirty")
+else:
+    print("clean")
+PYEOF
+}
+
+# Idempotency gate: returns 0 only when the host is fully converged on ADR-009 —
+# the workhorse has its alias + pin in model_settings.json AND no retired
+# ADR-006 tier is still pinned (absent-or-clean). An upgraded host with a
+# retired tier still pinned is NOT converged, so the unpin pass runs; a
+# converged host skips the whole start/pin/stop cycle (no server churn).
+# We only READ the oMLX-owned file here.
+pins_converged() {
     [ -f "$OMLX_HOME/model_settings.json" ] || return 1
-    python3 - "$OMLX_HOME/model_settings.json" "${TIER_MODELS[@]}" <<'PYEOF' 2>/dev/null
+    if ! python3 - "$OMLX_HOME/model_settings.json" "${TIER_MODELS[@]}" <<'PYEOF' 2>/dev/null
 import json, os, sys
 try:
     models = json.load(open(sys.argv[1])).get("models", {})
@@ -743,15 +793,24 @@ for t in sys.argv[2:]:
         sys.exit(1)
 sys.exit(0)
 PYEOF
+    then
+        return 1
+    fi
+    local r
+    for r in "${RETIRED_MODELS[@]}"; do
+        [ "$(retired_model_state "$(tier_repo "$r")")" = "dirty" ] && return 1
+    done
+    return 0
 }
 
-# --- Pin/alias via the oMLX admin API (ADR-006) -----------------------------
-# Sets each tier's alias + pin state by briefly starting the server, PUTting the
-# per-model settings, then stopping it — so ADR-005's end-state invariant (server
-# stopped after setup, no login autostart) is preserved. model_settings.json is
-# oMLX-owned, so we go through the admin API rather than writing the file. The
-# admin mount prefix is probed (it has drifted between /admin/api and /api). The
-# whole step degrades to print_pin_instructions + a warning — never a hard failure.
+# --- Pin/alias via the oMLX admin API (ADR-009) -----------------------------
+# Sets the workhorse alias + pin — and clears any retired ADR-006 tier pins — by
+# briefly starting the server, PUTting the per-model settings, then stopping it,
+# so ADR-005's end-state invariant (server stopped after setup, no login
+# autostart) is preserved. model_settings.json is oMLX-owned, so we go through
+# the admin API rather than writing the file. The admin mount prefix is probed
+# (it has drifted between /admin/api and /api). The whole step degrades to
+# print_pin_instructions + a warning — never a hard failure.
 apply_pins() {
     if ! $OMLX_PRESENT; then
         record_warn "pin" "omlx not installed — skipping admin pinning; re-run after installing omlx"
@@ -761,16 +820,20 @@ apply_pins() {
         record_warn "pin" "API key not readable — skipping admin pinning"
         print_pin_instructions; return
     fi
-    local any_present=false entry
+    local workhorse_present=false entry
     for entry in "${TIER_MODELS[@]}"; do
-        if [ -d "$(tier_dir "$entry")" ] && [ -n "$(ls -A "$(tier_dir "$entry")" 2>/dev/null)" ]; then any_present=true; fi
+        if [ -d "$(tier_dir "$entry")" ] && [ -n "$(ls -A "$(tier_dir "$entry")" 2>/dev/null)" ]; then workhorse_present=true; fi
     done
-    if ! $any_present; then
-        skip "pin" "no tier models on disk yet — download them (--download-model), then re-run to apply pins"
+    # If nothing is on disk AND oMLX has no model_settings.json, there is nothing
+    # to pin and nothing to unpin — skip without a server start. Do NOT gate on
+    # the workhorse alone: a prior ADR-006 install may still hold retired-tier
+    # pins that need clearing even before the workhorse is downloaded.
+    if ! $workhorse_present && [ ! -f "$OMLX_HOME/model_settings.json" ]; then
+        skip "pin" "workhorse not on disk and no model_settings.json — download it (--download-model), then re-run to apply pins"
         print_pin_instructions; return
     fi
-    if pins_already_applied; then
-        skip "pin" "all tier aliases + pins already set in model_settings.json (no server start needed)"
+    if pins_converged; then
+        skip "pin" "workhorse alias + pin set and no retired-tier pins to clear (no server start needed)"
         return
     fi
 
@@ -820,8 +883,7 @@ apply_pins() {
         alias="$(tier_alias "$entry")"
         pin="$(tier_pin "$entry")"
         if [ ! -d "$(tier_dir "$entry")" ]; then skip "pin-${alias}" "model ${mid} not on disk — skipping"; continue; fi
-        # PINNED tiers (T1/T2): co-resident, DFlash off. MAX tier: not pinned,
-        # idle-evict after 15 min, DFlash off (oMLX #702/#1892).
+        # The workhorse: sole resident model, pinned, DFlash off (oMLX #702/#1892).
         if [ "$pin" = "true" ]; then
             body="{\"model_alias\":\"${alias}\",\"is_pinned\":true,\"dflash_ssd_cache\":false}"
         else
@@ -833,6 +895,34 @@ apply_pins() {
         else
             record_warn "pin-${alias}" "admin PUT failed for ${mid} — set alias/pin manually at ${base}/admin"
         fi
+    done
+    if ! $workhorse_present; then
+        record_warn "pin" "workhorse model not on disk — download it with --download-model, then re-run to pin it (any retired-tier memory was still freed this run)"
+    fi
+
+    # Retired ADR-006 tiers: force-unpin whatever a prior install left pinned so
+    # the upgraded host actually frees the memory (ADR-009). Only entries already
+    # registered in model_settings.json are touched; the old alias is echoed back
+    # unchanged (see RETIRED_MODELS comment) and ttl_seconds bounds any
+    # accidental load of the now-unpinned model.
+    local r rmid rstate ralias
+    for r in "${RETIRED_MODELS[@]}"; do
+        rmid="$(basename "$(tier_repo "$r")")"
+        ralias="$(tier_alias "$r")"
+        rstate="$(retired_model_state "$(tier_repo "$r")")"
+        case "$rstate" in
+            absent) skip "unpin-${rmid}" "not in model_settings.json — never registered, nothing to unpin" ;;
+            clean)  skip "unpin-${rmid}" "already unpinned (DFlash off)" ;;
+            dirty)
+                body="{\"model_alias\":\"${ralias}\",\"is_pinned\":false,\"ttl_seconds\":900,\"dflash_ssd_cache\":false}"
+                if curl -fsS --max-time 20 -X PUT -H "$auth" -H 'Content-Type: application/json' \
+                    -d "$body" "${base}${admin}/models/${rmid}/settings" >/dev/null 2>&1; then
+                    ok "unpin-${rmid}" "retired tier unpinned (stays on disk; memory freed on next start)"
+                else
+                    record_warn "unpin-${rmid}" "admin PUT failed — unpin ${rmid} manually at ${base}/admin"
+                fi
+                ;;
+        esac
     done
 
     if $started_by_us; then
@@ -861,8 +951,7 @@ validate_endpoint() {
     if models="$(curl -fsS -H "$auth" "${base}/models" 2>/dev/null)"; then
         ok "validate-models" "GET /v1/models reachable"
         detail "$models"
-        # Every tier alias should be registered. The MAX tier (coding-quality) is
-        # on-demand: it is listed once discovered, but only loads on first request.
+        # The workhorse alias should be registered (single pinned model, ADR-009).
         local entry valias
         for entry in "${TIER_MODELS[@]}"; do
             valias="$(tier_alias "$entry")"
@@ -872,14 +961,27 @@ validate_endpoint() {
                 record_warn "validate-alias" "alias '${valias}' not found — apply pins (re-run setup) or set it in /admin"
             fi
         done
+        # No retired ADR-006 tier should still be pinned — a leftover pin holds
+        # ~30-45 GB that the fan-out's KV headroom is supposed to get (ADR-009).
+        local r rmid
+        for r in "${RETIRED_MODELS[@]}"; do
+            rmid="$(basename "$(tier_repo "$r")")"
+            if [ "$(retired_model_state "$(tier_repo "$r")")" = "dirty" ]; then
+                record_warn "validate-retired" "retired model ${rmid} is still pinned/DFlash-on — re-run setup to free its memory"
+            else
+                ok "validate-retired" "retired model ${rmid} not pinned"
+            fi
+        done
     else
         record_err "validate-models" "GET /v1/models failed — is the server running? (launchctl print gui/$(id -u)/${AGENT_LABEL})"
         return
     fi
 
-    # 2. chat completion
+    # 2. chat completion. max_tokens >= ~200 everywhere: GLM-4.7-Flash emits a
+    # reasoning preamble before the answer/tool call and 120 tokens truncated
+    # mid-call in testing (ADR-009).
     local chat_req chat_resp
-    chat_req='{"model":"'"$PRIMARY_ALIAS"'","messages":[{"role":"user","content":"Reply with the single word: pong"}],"max_tokens":16}'
+    chat_req='{"model":"'"$PRIMARY_ALIAS"'","messages":[{"role":"user","content":"Reply with the single word: pong"}],"max_tokens":256}'
     if chat_resp="$(curl -fsS -H "$auth" -H 'Content-Type: application/json' -d "$chat_req" "${base}/chat/completions" 2>/dev/null)"; then
         ok "validate-chat" "POST /v1/chat/completions returned a response"
         detail "$chat_resp"
@@ -889,7 +991,7 @@ validate_endpoint() {
 
     # 3. tool-calling
     local tool_req tool_resp
-    tool_req='{"model":"'"$PRIMARY_ALIAS"'","messages":[{"role":"user","content":"What files are in the current directory? Use the tool."}],"tools":[{"type":"function","function":{"name":"list_dir","description":"List files in a directory","parameters":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}}],"tool_choice":"auto","max_tokens":128}'
+    tool_req='{"model":"'"$PRIMARY_ALIAS"'","messages":[{"role":"user","content":"What files are in the current directory? Use the tool."}],"tools":[{"type":"function","function":{"name":"list_dir","description":"List files in a directory","parameters":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}}],"tool_choice":"auto","max_tokens":256}'
     if tool_resp="$(curl -fsS -H "$auth" -H 'Content-Type: application/json' -d "$tool_req" "${base}/chat/completions" 2>/dev/null)"; then
         if echo "$tool_resp" | grep -q 'tool_calls'; then
             ok "validate-tools" "model emitted tool_calls markup"
@@ -917,7 +1019,7 @@ validate_endpoint() {
 
     # 5. Anthropic-style messages endpoint (spec requires /v1/messages reachability)
     local msg_req msg_resp
-    msg_req='{"model":"'"$PRIMARY_ALIAS"'","max_tokens":16,"messages":[{"role":"user","content":"Reply with the single word: pong"}]}'
+    msg_req='{"model":"'"$PRIMARY_ALIAS"'","max_tokens":256,"messages":[{"role":"user","content":"Reply with the single word: pong"}]}'
     if msg_resp="$(curl -fsS -H "$auth" -H 'Content-Type: application/json' -d "$msg_req" "http://localhost:${PORT}/v1/messages" 2>/dev/null)"; then
         ok "validate-messages" "POST /v1/messages (Anthropic-style) reachable"
         detail "$msg_resp"

--- a/templates/omlx-start-wrapper.sh
+++ b/templates/omlx-start-wrapper.sh
@@ -60,9 +60,13 @@ fi
 # saturation surfaces as server-level backpressure, not Metal wiring failures. It
 # replaced the removed --max-process-memory flag (ADR-002); per oMLX #702 it
 # monitors Metal allocations, not total RSS.
-# --hot-cache-max-size accepts both absolute sizes ('18GB') and percentages
-# ('20%'). We pin an absolute 18GB for a deterministic hot-cache footprint
-# independent of how oMLX resolves a percentage (≈ 20% of the 90 GB guard).
+# --hot-cache-max-size accepts both absolute sizes ('24GB') and percentages
+# ('20%'). We pin an absolute 24GB for a deterministic hot-cache footprint
+# independent of how oMLX resolves a percentage (≈ 27% of the 90 GB guard — up
+# from ADR-006's 18GB: one model, no second cache to fund; ADR-009).
+# --max-concurrent-requests 10 is ADR-009's "Mark": safe concurrency is
+# prefill-activation-bound and context-dependent (measured 10 clean @ ~16K ctx);
+# excess requests queue at admission rather than aborting mid-flight.
 # --host pins the loopback bind explicitly so "local-only" does not depend on an
 # upstream default (one oMLX config class defaults to 0.0.0.0).
 exec "__BREW_PREFIX__/bin/omlx" serve \
@@ -71,6 +75,6 @@ exec "__BREW_PREFIX__/bin/omlx" serve \
     --port 8000 \
     --memory-guard-gb 90 \
     --paged-ssd-cache-dir "__CACHE_DIR__" \
-    --hot-cache-max-size 18GB \
-    --max-concurrent-requests 16 \
+    --hot-cache-max-size 24GB \
+    --max-concurrent-requests 10 \
     --api-key "$api_key"

--- a/templates/omlxctl
+++ b/templates/omlxctl
@@ -4,7 +4,7 @@
 #
 # The server is NOT started at login (the LaunchAgent is RunAtLoad=false). Startup
 # is intentional: this tool starts it on demand and stops it cleanly so the
-# resident model (~32 GB) + KV/prefix cache are released back to the system.
+# resident model (~30 GB) + KV/prefix cache are released back to the system.
 #
 # Usage:
 #   omlxctl start    Start the server (no-op if already running); wait for ready
@@ -46,8 +46,8 @@ STDOUT_LOG="${LOG_DIR}/launchagent.out.log"
 STDERR_LOG="${LOG_DIR}/launchagent.err.log"
 TAIL_LINES="${OMLX_TAIL_LINES:-80}"
 
-# Cold start loads ~32 GB from disk and wires it; ~90s is typical, so poll /health
-# up to READY_TIMEOUT. SIGTERM flushes up to 18 GB of hot cache to SSD on shutdown,
+# Cold start loads ~30 GB from disk and wires it; ~90s is typical, so poll /health
+# up to READY_TIMEOUT. SIGTERM flushes up to 24 GB of hot cache to SSD on shutdown,
 # so allow STOP_TIMEOUT before escalating to SIGKILL. (ADR-005; omlx serve timings.)
 READY_TIMEOUT="${OMLX_READY_TIMEOUT:-120}"
 STOP_TIMEOUT="${OMLX_STOP_TIMEOUT:-30}"
@@ -94,7 +94,7 @@ _wait_ready() {
         return 0
     fi
     local deadline=$(( $(date +%s) + READY_TIMEOUT ))
-    info "Waiting for ${HEALTH_URL} (up to ${READY_TIMEOUT}s; cold start loads ~32 GB)"
+    info "Waiting for ${HEALTH_URL} (up to ${READY_TIMEOUT}s; cold start loads ~30 GB)"
     while :; do
         if _health_ok; then return 0; fi
         if ! _is_running; then

--- a/templates/pi-models-omlx.json
+++ b/templates/pi-models-omlx.json
@@ -12,16 +12,14 @@
 //   supportsReasoningEffort: false  — reasoning_effort is not implemented
 //   supportsUsageInStreaming: false — streaming usage stats not guaranteed
 //
-// Three tiers (ADR-006), addressed by their oMLX ALIASES (verified to resolve on
-// the installed version):
-//   coding-fast      T1  Qwen3-Coder-30B-A3B-8bit   pinned, co-resident
-//   coding-balanced  T2  GLM-4.7-Flash-8bit          pinned, co-resident
-//   coding-quality   MAX Qwen3-Coder-Next-4bit       on-demand (lazy-loads ~16 s on
-//                                                     first request, idle-evicts)
+// Single workhorse model (ADR-009), addressed by its oMLX ALIAS (verified to
+// resolve on the installed version):
+//   coding-workhorse  GLM-4.7-Flash-8bit  pinned, sole resident model
+// High-fidelity work routes to the cloud frontier, not this provider.
 //
-// contextWindow is held to 131072 (≈ half the models' native context): 16
-// concurrent sessions at full context would overrun the KV/wired budget and
-// collapse prefix-cache reuse.
+// contextWindow is held to 131072 (inside GLM's 202K native context): safe
+// concurrency is prefill-activation-bound and falls as context grows (ADR-009
+// "The Mark": 10 @ ~16K ctx), so sessions should not fill the native window.
 {
   "providers": {
     "omlx": {
@@ -36,26 +34,8 @@
       },
       "models": [
         {
-          "id": "__T1_ID__",
-          "name": "coding-fast — Qwen3-Coder-30B-A3B (local oMLX)",
-          "reasoning": false,
-          "input": ["text"],
-          "contextWindow": __PI_CONTEXT_WINDOW__,
-          "maxTokens": __PI_MAX_TOKENS__,
-          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
-        },
-        {
-          "id": "__T2_ID__",
-          "name": "coding-balanced — GLM-4.7-Flash (local oMLX)",
-          "reasoning": false,
-          "input": ["text"],
-          "contextWindow": __PI_CONTEXT_WINDOW__,
-          "maxTokens": __PI_MAX_TOKENS__,
-          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
-        },
-        {
-          "id": "__MAX_ID__",
-          "name": "coding-quality — Qwen3-Coder-Next (local oMLX, on-demand)",
+          "id": "__MODEL_ID__",
+          "name": "coding-workhorse — GLM-4.7-Flash (local oMLX)",
           "reasoning": false,
           "input": ["text"],
           "contextWindow": __PI_CONTEXT_WINDOW__,


### PR DESCRIPTION
## Summary

Implements ADR-009: the Mac becomes a single-model subagent workhorse (GLM-4.7-Flash-8bit pinned as `coding-workhorse`) with the cloud as the quality frontier. The three-tier ADR-006 lineup is retired, ADR-006/008 are formally superseded (the step ADR-009 deliberately deferred to this PR), and every doc surface is synced. Closes #14.

## Type of Change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Changes

- **`setup-omlx-m5.sh`** — `TIER_MODELS` collapses to one entry (all existing loops work unchanged over one element); new `RETIRED_MODELS` + `retired_model_state()` + `pins_converged` gate so `apply_pins` actively **unpins retired ADR-006 tiers** on an upgraded host (models stay on disk; Qwen3-Coder-30B is the documented inactive fallback); `MIN_DISK_GB` 140→60; `--validate` bumps `max_tokens` to 256 (GLM reasoning-preamble floor — at the old 16/128 the tool-call check would false-WARN) and warns if a retired tier is still pinned.
- **Templates** — wrapper: `--hot-cache-max-size 24GB`, `--max-concurrent-requests 10` ("The Mark", validated on-host); Pi provider: single `__MODEL_ID__` entry.
- **ADR supersession** — 006 and 008 → `superseded by ADR-009`; ADR-009 → plain `accepted`, Relationship section declares the supersession with the implementation date.
- **Docs** — README / CLAUDE.md / macos brief (including the long-stale "rejects percentages" claim) / router-wiring synced. router-wiring also lands three review fixes: `MaxTokens` plumbed end-to-end, unserved roles throw `InferenceUnavailableException` (not `ArgumentOutOfRangeException`) so the chain reaches the cloud frontier, and the tool-call guard is pinned to wrap the backend (not the router). New `docs/workhorse-probes.md` records the two one-time on-host probes (≥16K MLA re-check, `enable_thinking` pass-through). `omlx-expert` wrapper pair current-pick updated in sync.

## Test Plan

- `bash -n` on all three shell files + `--help` render: pass.
- `linter` agent: shellcheck (severity=warning) 0 findings; markdownlint-cli2 0 findings across all touched markdown — **Verdict: PASS**.
- Grep gate: no residual `coding-fast/balanced/quality` or `__T1/T2/MAX_ID__` outside historical ADRs/research docs and the deliberate RETIRED_MODELS/teardown mentions.
- Pi template render dry-run: zero unsubstituted placeholders, JSONC parses, single `coding-workhorse` entry.
- **On-host (post-merge, operator):** re-run `./setup-omlx-m5.sh` on the M5 Max (wrapper re-render bounces a running server — restart with `omlxctl start`), `--validate` 5/5, then the `docs/workhorse-probes.md` probes.

## Checklist

- [x] No secrets, keys, or personal paths introduced
- [x] Doc-sync surfaces from the approved plan all touched (script, templates, README, CLAUDE.md, macos brief, router-wiring, ADRs 006/008/009, omlx-expert pair, workhorse-probes.md); historical ADRs/research docs deliberately untouched
- [x] Idempotency preserved: converged host short-circuits with no server start; upgraded ADR-006 host converges in one re-run
- [x] Per-task gate evidence: linter PASS, syntax checks pass, self-review done