### PR TITLE
fix(setup): admin session login for oMLX >= 0.4.4 pin API

### DIFF
--- a/docs/workhorse-probes.md
+++ b/docs/workhorse-probes.md
@@ -5,6 +5,14 @@ any oMLX or model update), closing the residual risks the ADR-009 review
 flagged. Neither is part of `--validate` — both need a long prompt or a
 model-behavior judgement that the scripted checks deliberately avoid.
 
+> **Last run: 2026-07-02, oMLX 0.4.4 — both probes PASS.** Probe 1: baseline
+> 30.0 GB resident; a 19,470-token prompt added +2.1 GB resident / +7.0 GB peak
+> (MLA-class — an MHA fallback would have added ~18 GB), with 19,456/19,470
+> tokens prefix-cache-hit on repeat. Probe 2: `enable_thinking:false` accepted —
+> completion dropped from 38 tokens (reasoning field present) to 1 token.
+> Orchestrators MAY send `chat_template_kwargs: {"enable_thinking": false}` on
+> oMLX ≥ 0.4.4; keep the `max_tokens ≥ 200` floor regardless.
+
 Prereqs: server provisioned, `omlxctl start` done, `KEY="$(cat ~/.omlx/api-key)"`.
 
 ## 1. Long-context MLA-compression probe (≥16K tokens)
@@ -21,7 +29,7 @@ at ~7.3K tokens; this re-check covers the 9–16K range the fan-out actually use
 
    ```bash
    omlxctl status
-   vmmap --summary "$(pgrep -f 'omlx serve')" | grep -i 'physical footprint'
+   vmmap --summary "$(pgrep -x omlx-server)" | grep -i 'physical footprint'
    ```
 
 2. Send one completion with a ≥16K-token prompt (any large file dump works —

--- a/setup-omlx-m5.sh
+++ b/setup-omlx-m5.sh
@@ -375,7 +375,12 @@ install_wired_limit() {
         ok "wired-daemon" "installed $DAEMON_PLIST (root:wheel 0644)"
     fi
 
-    if sudo launchctl print "system/${DAEMON_LABEL}" >/dev/null 2>&1; then
+    # Loaded-check without sudo first: `launchctl print system/<label>` is
+    # readable unprivileged, and a sudo-wrapped check fails under NON-INTERACTIVE
+    # sudo even when the job IS loaded — which then mis-fires a bootstrap attempt
+    # and records a spurious error on an already-converged host.
+    if launchctl print "system/${DAEMON_LABEL}" >/dev/null 2>&1 \
+        || sudo launchctl print "system/${DAEMON_LABEL}" >/dev/null 2>&1; then
         skip "wired-daemon" "LaunchDaemon already loaded"
     else
         if sudo launchctl bootstrap system "$DAEMON_PLIST"; then

--- a/setup-omlx-m5.sh
+++ b/setup-omlx-m5.sh
@@ -865,13 +865,26 @@ apply_pins() {
         print_pin_instructions; return
     fi
 
-    # Probe the admin mount prefix.
+    # Admin auth: oMLX >= 0.4.4 requires a session login (POST /admin/api/login
+    # with the API key -> session cookie); the bearer key alone gets a 401
+    # "Admin authentication required". Older builds accepted the bearer key
+    # directly, so the probe below still sends both — the cookie jar is empty
+    # (harmless) when the login endpoint does not exist.
+    local cookie_jar
+    cookie_jar="$(mktemp)"
+    if curl -fsS --max-time 5 -c "$cookie_jar" -H 'Content-Type: application/json' \
+        -d "{\"api_key\":\"${key}\"}" "${base}/admin/api/login" >/dev/null 2>&1; then
+        detail "admin session established via /admin/api/login"
+    fi
+
+    # Probe the admin mount prefix (cookie + bearer — whichever the build honors).
     local admin="" p
     for p in "/admin/api" "/api"; do
-        if curl -fsS --max-time 5 -H "$auth" "${base}${p}/models" >/dev/null 2>&1; then admin="$p"; break; fi
+        if curl -fsS --max-time 5 -b "$cookie_jar" -H "$auth" "${base}${p}/models" >/dev/null 2>&1; then admin="$p"; break; fi
     done
     if [ -z "$admin" ]; then
         record_warn "pin" "admin API not found at /admin/api or /api — apply pins manually"
+        rm -f "$cookie_jar"
         $started_by_us && "$CONTROL_PATH" stop >/dev/null 2>&1 || true
         print_pin_instructions; return
     fi
@@ -889,7 +902,7 @@ apply_pins() {
         else
             body="{\"model_alias\":\"${alias}\",\"is_pinned\":false,\"ttl_seconds\":900,\"dflash_ssd_cache\":false}"
         fi
-        if curl -fsS --max-time 20 -X PUT -H "$auth" -H 'Content-Type: application/json' \
+        if curl -fsS --max-time 20 -X PUT -b "$cookie_jar" -H "$auth" -H 'Content-Type: application/json' \
             -d "$body" "${base}${admin}/models/${mid}/settings" >/dev/null 2>&1; then
             ok "pin-${alias}" "alias '${alias}' (pinned=${pin}) set for ${mid}"
         else
@@ -915,7 +928,7 @@ apply_pins() {
             clean)  skip "unpin-${rmid}" "already unpinned (DFlash off)" ;;
             dirty)
                 body="{\"model_alias\":\"${ralias}\",\"is_pinned\":false,\"ttl_seconds\":900,\"dflash_ssd_cache\":false}"
-                if curl -fsS --max-time 20 -X PUT -H "$auth" -H 'Content-Type: application/json' \
+                if curl -fsS --max-time 20 -X PUT -b "$cookie_jar" -H "$auth" -H 'Content-Type: application/json' \
                     -d "$body" "${base}${admin}/models/${rmid}/settings" >/dev/null 2>&1; then
                     ok "unpin-${rmid}" "retired tier unpinned (stays on disk; memory freed on next start)"
                 else
@@ -924,6 +937,7 @@ apply_pins() {
                 ;;
         esac
     done
+    rm -f "$cookie_jar"
 
     if $started_by_us; then
         if "$CONTROL_PATH" stop >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Live testing of the ADR-009 rework (PR #17) on the M5 Max surfaced one real bug: oMLX 0.4.4 requires a session login (`POST /admin/api/login` with the API key → cookie) for the `/admin/api` surface — the bearer key alone gets 401 "Admin authentication required", so `apply_pins` could not apply or clear any pin. The fix establishes the session into a `mktemp` cookie jar and sends both cookie and bearer on the probe and PUTs, staying compatible with older builds that honored bearer alone.

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Test Plan

Executed end-to-end on the target M5 Max (oMLX 0.4.4, upgrade path from a partial ADR-006 install):

- **Setup re-run with the fix:** `coding-workhorse` pinned + aliased on GLM-4.7-Flash-8bit; retired Qwen-30B **unpinned** (was pinned as `coding-fast`); never-registered Qwen-Next correctly skipped; second re-run short-circuits via `pins_converged` with no server start.
- **`--validate`: 8/8 PASS** — models, workhorse alias, both retired-tier checks, chat, tool_calls, 2-way concurrency, `/v1/messages`.
- **Probe 1 (long-context MLA): PASS.** Baseline 30.0 GB resident; a 19,470-token prompt added +2.1 GB resident / +7.0 GB peak — MLA-class (an MHA fallback implies ~18 GB KV for that prompt). Prefix cache: 19,456/19,470 cached on repeat (22.2s → 6.1s).
- **Probe 2 (`enable_thinking`): PASS.** `chat_template_kwargs: {"enable_thinking": false}` honored — completion 38 → 1 token, reasoning field gone. Recorded in `docs/workhorse-probes.md`.
- **10-way fan-out at "The Mark":** 10/10 valid completions, 0 failures, 5s wall.
- shellcheck (severity=warning) clean; markdownlint clean on touched files.

## Checklist

- [x] No secrets in the diff; cookie jar is a 0600 mktemp file removed before return
- [x] Idempotency preserved (converged short-circuit verified live)
- [x] `docs/workhorse-probes.md` process-name fix (`omlx-server`) + probe results recorded