### PR TITLE
fix(setup): stop half-started server on start timeout; review hardening

### DIFF
--- a/.claude/agents/apple-silicon-inference-expert.md
+++ b/.claude/agents/apple-silicon-inference-expert.md
@@ -37,8 +37,9 @@ questions, defer to `amd-inference-expert`.
   (98304 MB), leaving ~32 GB for macOS. The value is **not** persistent across reboot —
   a root LaunchDaemon applies it at boot (mechanics live in `omlx-expert`).
 - A single resident model maximizes KV/prefix-cache headroom; co-residency of two
-  large models roughly halves it. (This project deliberately co-resides two ~30 GB
-  tiers under the ceiling, leaving ~29 GB for KV.)
+  large models roughly halves it. (This project pins a single ~30 GB workhorse,
+  leaving ~60 GB for KV under the 90 GB guard — ADR-009; the earlier ADR-006
+  lineup co-resided two ~30 GB tiers at ~29 GB KV.)
 
 ### MLX frameworks & the serving path
 

--- a/.claude/agents/omlx-expert.md
+++ b/.claude/agents/omlx-expert.md
@@ -28,9 +28,9 @@ over single-stream tok/s). You return advice and exact commands; you never modif
 - `omlx serve` flags: `--host` (pin `127.0.0.1`), `--port` (default `8000`),
   `--model-dir`, `--memory-guard-gb` (replaced the removed `--max-process-memory`;
   caps Metal allocations, not total RSS), `--paged-ssd-cache-dir`,
-  `--hot-cache-max-size` (**accepts both absolute sizes like `18GB` and percentages
-  like `20%`**), `--max-concurrent-requests` (**default 8**; this project sets 16),
-  `--api-key`.
+  `--hot-cache-max-size` (**accepts both absolute sizes like `24GB` and percentages
+  like `20%`**), `--max-concurrent-requests` (**default 8**; this project sets 10 —
+  ADR-009 "The Mark"), `--api-key`.
 - Endpoints: OpenAI `GET /v1/models`, `POST /v1/chat/completions`; Anthropic
   `POST /v1/messages`.
 - Admin panel at `/admin`; per-model `model_type_override`
@@ -43,8 +43,9 @@ over single-stream tok/s). You return advice and exact commands; you never modif
   engine, which **crashes on the second concurrent request** (oMLX issue #1800, open).
 - Mitigation if such a model is unavoidable: set `model_type_override = llm`. The
   far better choice is a **text-only checkpoint** (`*ForCausalLM`, no `vision_config`)
-  so no override is needed. This repo deliberately ships only the text-only
-  Qwen3-Coder build for exactly this reason.
+  so no override is needed. This repo deliberately serves only verified text-only
+  coder builds (the ADR-009 GLM workhorse; previously the Qwen3-Coder tiers) for
+  exactly this reason.
 - Always inspect a candidate's `config.json` (`architectures`, `vision_config`)
   *before* downloading. Every MLX repack of a natively-multimodal model (e.g. any
   Qwen3.6-35B-A3B repo, mlx-community **or** unsloth) carries the trap.

--- a/.github/agents/apple-silicon-inference-expert.agent.md
+++ b/.github/agents/apple-silicon-inference-expert.agent.md
@@ -39,8 +39,9 @@ questions, defer to `amd-inference-expert`.
   (98304 MB), leaving ~32 GB for macOS. The value is **not** persistent across reboot —
   a root LaunchDaemon applies it at boot (mechanics live in `omlx-expert`).
 - A single resident model maximizes KV/prefix-cache headroom; co-residency of two
-  large models roughly halves it. (This project deliberately co-resides two ~30 GB
-  tiers under the ceiling, leaving ~29 GB for KV.)
+  large models roughly halves it. (This project pins a single ~30 GB workhorse,
+  leaving ~60 GB for KV under the 90 GB guard — ADR-009; the earlier ADR-006
+  lineup co-resided two ~30 GB tiers at ~29 GB KV.)
 
 ### MLX frameworks & the serving path
 

--- a/.github/agents/omlx-expert.agent.md
+++ b/.github/agents/omlx-expert.agent.md
@@ -30,9 +30,9 @@ over single-stream tok/s). You return advice and exact commands; you never modif
 - `omlx serve` flags: `--host` (pin `127.0.0.1`), `--port` (default `8000`),
   `--model-dir`, `--memory-guard-gb` (replaced the removed `--max-process-memory`;
   caps Metal allocations, not total RSS), `--paged-ssd-cache-dir`,
-  `--hot-cache-max-size` (**accepts both absolute sizes like `18GB` and percentages
-  like `20%`**), `--max-concurrent-requests` (**default 8**; this project sets 16),
-  `--api-key`.
+  `--hot-cache-max-size` (**accepts both absolute sizes like `24GB` and percentages
+  like `20%`**), `--max-concurrent-requests` (**default 8**; this project sets 10 —
+  ADR-009 "The Mark"), `--api-key`.
 - Endpoints: OpenAI `GET /v1/models`, `POST /v1/chat/completions`; Anthropic
   `POST /v1/messages`.
 - Admin panel at `/admin`; per-model `model_type_override`
@@ -45,8 +45,9 @@ over single-stream tok/s). You return advice and exact commands; you never modif
   engine, which **crashes on the second concurrent request** (oMLX issue #1800, open).
 - Mitigation if such a model is unavoidable: set `model_type_override = llm`. The
   far better choice is a **text-only checkpoint** (`*ForCausalLM`, no `vision_config`)
-  so no override is needed. This repo deliberately ships only the text-only
-  Qwen3-Coder build for exactly this reason.
+  so no override is needed. This repo deliberately serves only verified text-only
+  coder builds (the ADR-009 GLM workhorse; previously the Qwen3-Coder tiers) for
+  exactly this reason.
 - Always inspect a candidate's `config.json` (`architectures`, `vision_config`)
   *before* downloading. Every MLX repack of a natively-multimodal model (e.g. any
   Qwen3.6-35B-A3B repo, mlx-community **or** unsloth) carries the trap.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ so the script never writes it directly); it degrades to printed manual
 admin-panel steps if the API can't be reached (ADR-009).
 
 Preflight hard-fails with exit `2` for non-macOS, non-arm64, RAM below ~120 GB,
-free disk below ~60 GB, or missing Homebrew. M5 Max is the tuned target; a
+free disk below ~90 GB, or missing Homebrew. M5 Max is the tuned target; a
 non-M5 Apple Silicon chip warns instead of hard-failing so nearby Max-class hosts
 can still smoke-test deliberately.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Stand up a **local, OpenAI/Anthropic-compatible LLM inference server** on an App
 
 ## TL;DR — start now
 
-You need: an Apple Silicon Mac with **128 GB unified memory** (tuned for M5 Max; other Max-class chips warn but work), ~60 GB free disk (the workhorse model ≈ 30 GB plus staging/cache headroom), macOS, and [Homebrew](https://brew.sh). One step needs `sudo` (GPU wired-memory limit).
+You need: an Apple Silicon Mac with **128 GB unified memory** (tuned for M5 Max; other Max-class chips warn but work), ~90 GB free disk (the workhorse model ≈ 30 GB, up to 24 GB of hot-cache flush to SSD, plus staging headroom), macOS, and [Homebrew](https://brew.sh). One step needs `sudo` (GPU wired-memory limit).
 
 ```bash
 git clone https://github.com/psmfd/local-llm.git && cd local-llm
@@ -23,7 +23,7 @@ The script is idempotent — re-running it skips whatever already exists. Run `.
 
 `setup-omlx-m5.sh` performs, in order:
 
-1. **Preflight** — hard-fails (exit `2`) on non-macOS, non-arm64, <~120 GB RAM, <~60 GB free disk, or missing Homebrew.
+1. **Preflight** — hard-fails (exit `2`) on non-macOS, non-arm64, <~120 GB RAM, <~90 GB free disk, or missing Homebrew.
 2. **Installs oMLX** via `brew tap jundot/omlx && brew install omlx` (no MCP — tool access stays explicit).
 3. **Creates directories** — `~/models`, `~/.omlx/{cache,logs,bin}` (`~/.omlx` is chmod 700).
 4. **Generates an API key** at `~/.omlx/api-key` (chmod 600, never printed).

--- a/macos/local-llm-mac-os-creation.md
+++ b/macos/local-llm-mac-os-creation.md
@@ -31,7 +31,7 @@ These came out of prior analysis. Treat the runtime and serving config as decide
 
 ## What to do
 
-1. **Verify environment** — macOS, arm64, RAM ≥ ~120 GB, free disk ≥ ~60 GB (workhorse ≈ 30 GB + staging/cache), Homebrew present. Abort with exit 2 on those hard precondition failures. Treat M5 Max as the tuned target; warn rather than hard-fail on non-M5 Apple Silicon so nearby Max-class hosts can smoke-test deliberately.
+1. **Verify environment** — macOS, arm64, RAM ≥ ~120 GB, free disk ≥ ~90 GB (workhorse ≈ 30 GB + up-to-24 GB hot-cache flush + staging), Homebrew present. Abort with exit 2 on those hard precondition failures. Treat M5 Max as the tuned target; warn rather than hard-fail on non-M5 Apple Silicon so nearby Max-class hosts can smoke-test deliberately.
 2. **Author or reuse the setup script.** If `setup-omlx-m5.sh` already exists in the working directory, review it against the spec above and the conventions, then use it. Otherwise write it. It must: install oMLX (no MCP extra); create `~/models`, `~/.omlx/cache`, `~/.omlx/logs`; generate the 0600 API key; set + persist the wired limit; write the start wrapper; install the on-demand LaunchAgent (RunAtLoad=false) and the `omlxctl` control tool, leaving the server stopped; leave model download opt-in (default off) routing to the `/admin` downloader unless repo IDs are verified.
 3. **Lint it.** Run `shellcheck` and fix all Error/Warning findings; report results in the structured review format with a verdict line.
 4. **Run it**, supplying sudo when prompted for the wired-limit step.

--- a/setup-omlx-m5.sh
+++ b/setup-omlx-m5.sh
@@ -80,9 +80,11 @@ WIRED_LIMIT_MB=98304    # 96 GB; leaves ~32 GB for macOS on a 128 GB host (ADR-0
 WIRED_MIN_MB=90000      # wrapper warns below this
 
 MIN_RAM_GB=120
-MIN_DISK_GB=60          # GLM-4.7-Flash-8bit (~30 GB) + hf staging/logs headroom (ADR-009).
-                        # Gates required FREE space only — retired ADR-006 tiers
-                        # already on disk are sunk cost, not part of this floor.
+MIN_DISK_GB=90          # GLM-4.7-Flash-8bit (~30 GB) + up-to-24 GB hot-cache flush
+                        # to ~/.omlx/cache on every stop + hf staging/logs headroom
+                        # (ADR-009). Gates required FREE space only — retired
+                        # ADR-006 tiers already on disk are sunk cost, not part
+                        # of this floor.
 
 # --- Model lineup (ADR-009: single Mac workhorse, cloud is the frontier) -----
 # ADR-006's three co-resident/on-demand tiers are retired: the cloud provider is
@@ -752,7 +754,8 @@ print_pin_instructions() {
 }
 
 # retired_model_state REPO — reads the LOCAL oMLX-owned model_settings.json
-# (never the server) and prints:
+# (never the server; schema — basename-keyed "models" map with model_alias /
+# is_pinned / dflash_ssd_cache fields — verified against oMLX 0.4.4) and prints:
 #   absent  oMLX has never registered this model — no PUT should be sent
 #           (retired tiers are never actively aliased/registered by us)
 #   dirty   present and still is_pinned or dflash_ssd_cache — needs an unpin PUT
@@ -854,7 +857,14 @@ apply_pins() {
         if [ -x "$CONTROL_PATH" ] && "$CONTROL_PATH" start >/dev/null 2>&1; then
             started_by_us=true
         else
-            record_warn "pin" "could not start the server to apply pins (omlxctl start failed)"
+            # omlxctl start returns non-zero both when kickstart fails AND when
+            # kickstart succeeded but readiness timed out — in the timeout case
+            # the server IS running and still loading the model. Best-effort
+            # stop either way (safe: the health probe above said nothing was
+            # running before we tried), so setup never leaves a half-started
+            # server resident (ADR-005 end-state invariant).
+            [ -x "$CONTROL_PATH" ] && "$CONTROL_PATH" stop >/dev/null 2>&1 || true
+            record_warn "pin" "server did not start or did not become ready in time — stopped any partial start; re-run setup to apply pins"
             print_pin_instructions; return
         fi
     fi
@@ -870,13 +880,27 @@ apply_pins() {
         print_pin_instructions; return
     fi
 
+    # oMLX persists its CLI args — including a copy of the API key — into
+    # settings.json, written 0644 on the first-ever start. ensure_dirs only
+    # tightens a pre-existing file, so close the gap here, right after the
+    # first start this run may have triggered.
+    [ -f "$OMLX_HOME/settings.json" ] && chmod 600 "$OMLX_HOME/settings.json" 2>/dev/null || true
+
     # Admin auth: oMLX >= 0.4.4 requires a session login (POST /admin/api/login
-    # with the API key -> session cookie); the bearer key alone gets a 401
+    # with the API key -> session cookie; the "api_key" body field name is
+    # verified against oMLX 0.4.4); the bearer key alone gets a 401
     # "Admin authentication required". Older builds accepted the bearer key
     # directly, so the probe below still sends both — the cookie jar is empty
     # (harmless) when the login endpoint does not exist.
+    # SECURITY NOTE: the key rides curl's argv (-H/-d) for these brief admin
+    # calls — visible to other local accounts via ps for each subprocess's
+    # lifetime. Same accepted gap as the wrapper's --api-key (ADR-001):
+    # loopback-only server on a single-user host.
+    # The session-cookie jar lives under the 0700 $OMLX_HOME (not shared /tmp),
+    # so even an abnormal exit that skips the rm below leaves the residue
+    # unreadable to other accounts.
     local cookie_jar
-    cookie_jar="$(mktemp)"
+    cookie_jar="$(mktemp "${OMLX_HOME}/.admin-cookie.XXXXXX")"
     if curl -fsS --max-time 5 -c "$cookie_jar" -H 'Content-Type: application/json' \
         -d "{\"api_key\":\"${key}\"}" "${base}/admin/api/login" >/dev/null 2>&1; then
         detail "admin session established via /admin/api/login"


### PR DESCRIPTION
## Summary

Closes out the release-readiness review of `main..dev` (three-way fan-out: code-review-expert NEEDS_CHANGES, security-review-expert PASS_WITH_WARNINGS, linter PASS). Fixes the one Error — a start-readiness timeout left a still-loading server resident, violating ADR-005's leaves-it-stopped invariant — plus every Warning/Info the reviewers raised. After this merges, the release scope is clean for a `dev` → `main` promotion.

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — maintenance
- [ ] `refactor` — restructuring without behavior change
- [ ] `test` — adding or updating tests
- [ ] `ci` — CI/CD changes
- [ ] `style` — formatting or linting fixes
- [ ] Breaking change (add `!` to PR title)

## Changes

| Review finding | Fix |
|---|---|
| **Error** — start timeout leaves server resident (ADR-005 violation) | Best-effort `omlxctl stop` on the failed-start branch (safe: health probe confirmed nothing was running first); corrected message |
| **Warning** — `MIN_DISK_GB=60` ignores the 24 GB hot-cache flush | 60 → 90, comment explains the budget; README / CLAUDE.md / macos brief synced |
| **Warning** — API key on curl argv in admin calls (new uncovered sites) | SECURITY NOTE extended to cover `apply_pins` explicitly (same accepted gap as ADR-001) |
| **Warnings ×3** — stale agent-wrapper facts missed by the #17 doc sync | omlx-expert pair: concurrency 16→10, "ships only Qwen3-Coder"→workhorse; apple-silicon pair: co-residency fact → ADR-009 |
| **Info** — cookie jar in shared $TMPDIR, no abnormal-exit cleanup | Jar moved under the 0700 `~/.omlx` (residue unreadable to other accounts even on abnormal exit); explicit `rm` on all normal paths unchanged |
| **Info** — first-run `settings.json` written 0644, tightened only next run | `chmod 600` right after the first start this run triggers |
| **Info** — 0.4.4-only schema/login-field assumptions undocumented | "verified against oMLX 0.4.4" comments on both |

## Test Plan

- shellcheck (severity=warning) and `bash -n`: clean.
- markdownlint-cli2 on all touched markdown: clean (sole repo-wide error is the gitignored `.session-notes/` file, never in CI).
- Live converged re-run on the M5 Max: **PASS — 0 errors, 0 warnings** (short-circuit intact; the new branches are timeout/fresh-host paths not reachable on a converged host — verified by inspection + shellcheck).

## Checklist

- [x] All review findings addressed or explicitly covered (the trap-on-abnormal-exit suggestion is superseded by the 0700-dir containment — noted in the code comment)
- [x] Doc-sync surfaces for the MIN_DISK_GB change updated (README, CLAUDE.md, macos brief)
- [x] Agent wrapper pairs kept in sync (Claude + Copilot mirrors)