### PR TITLE
docs(probes): add sustained-concurrency probe results

### DIFF
--- a/docs/workhorse-probes.md
+++ b/docs/workhorse-probes.md
@@ -12,6 +12,9 @@ model-behavior judgement that the scripted checks deliberately avoid.
 > completion dropped from 38 tokens (reasoning field present) to 1 token.
 > Orchestrators MAY send `chat_template_kwargs: {"enable_thinking": false}` on
 > oMLX ≥ 0.4.4; keep the `max_tokens ≥ 200` floor regardless.
+>
+> **Probe 3 run: 2026-07-04, oMLX 0.4.4 — sustained N=10 FAILS, N=8 PASSES**
+> (see the probe-3 section below for the full matrix, including the 6-bit A/B).
 
 Prereqs: server provisioned, `omlxctl start` done, `KEY="$(cat ~/.omlx/api-key)"`.
 
@@ -79,7 +82,63 @@ tool-bearing requests instead of relying only on generous `max_tokens` (keep
 or ignores the field:** stick with the `max_tokens` floor; re-test after oMLX
 upgrades.
 
-## Recording results
+## 3. Sustained-concurrency probe (the Mark under continuous load)
+
+**Why.** ADR-009's "Mark" (`--max-concurrent-requests 10`, measured 10 clean at
+~16K ctx) was a single-shot burst measurement. A parallel-agent orchestrator can
+re-fire the moment responses land, so the operating point must also hold under
+back-to-back waves with zero think time — the worst case being N *distinct*
+~16K system prefixes (one per subagent persona) that all miss the prefix cache.
+
+**Procedure.** Fire waves of N concurrent `/v1/chat/completions` requests
+(~16K-token distinct system prefixes, `max_tokens` 300) back-to-back for 8–30
+minutes; after each wave sample `vmmap --summary` physical footprint,
+`memory_pressure -Q`, and `pmset -g therm`. Watch the server log for
+`Preflight rejected` / `Hard memory pressure` lines.
+
+**Results (2026-07-04, oMLX 0.4.4, M5 Max 128 GB, guard 90 GB, hot-cache 24 GB —
+enforcer thresholds derived from the guard: soft 76.5 GB, hard 85.5 GB):**
+
+| Model | N | Outcome | Footprint plateau | Margin to hard threshold |
+| --- | --- | --- | --- | --- |
+| 8-bit (30 GB) | 10 | **COLLAPSE** — 50/2,690 ok after wave 1 (30 min) | 94–102 GB RSS | none — pressure spiral |
+| 8-bit (30 GB) | 8 | clean 64/64, wave time creep 57→66 s | ~81.5 GB | ~4 GB |
+| 8-bit (30 GB) | 6 | clean 66/66, stable | ~64 GB | comfortable |
+| 6-bit (23 GB) | 10 | 50/60 — one full wave rejected, recovered | 96–97 GB RSS | intermittent spiral |
+| 6-bit (23 GB) | 8 | clean 64/64 | ~78 GB | ~8 GB |
+
+**Failure mechanism (from the server log).** Ten concurrent cold ~16K prefills
+push oMLX's tracked memory into the enforcer's hard-pressure band; the enforcer
+*lowers the dynamic admission ceiling* (observed 90 → 81.5 GB) and LRU-evicts
+the prefix cache, so retries arrive `cached=0` and need a full ~6.9 GB KV+SDPA
+preflight each — predicted peak ~92 GB > ceiling → instant **HTTP 400**
+(`oMLX prefill memory guard rejected this prompt`). The eviction keeps the
+cache cold, so the reject-loop self-sustains until load stops (recovery to
+`pressure ok` took seconds once idle). RSS meanwhile exceeded the guard
+(101.9 GB peak) — the guard tracks Metal allocations, not RSS (#702). The host
+itself stayed healthy throughout: no thermal `CPU_Speed_Limit` engaged on the
+16-inch chassis (Mac17,6) and system memory pressure never went critical.
+
+**Operational consequences.**
+
+- The Mark = 10 is a **burst** ceiling, not a sustained operating point.
+  Sustained-safe worst case on the 8-bit build is **N=8** (slim margin) and
+  N=6 is comfortable; the 6-bit build widens N=8 margin to ~8 GB but still
+  blips at N=10.
+- Saturation surfaces to clients as **HTTP 400**, not 429/503. Router/client
+  retry logic must treat this specific 400 (`prefill memory guard rejected`)
+  as a capacity signal (backoff/retry or route to the cloud frontier), not a
+  permanent client error.
+- Prefix-cache reuse works when the enforcer is unpressured (~24.6 s cold vs
+  ~7 s warm for a 16K prefix, single stream) — protecting the cache from
+  pressure-driven eviction is exactly why the sustained N must stay below the
+  spiral point.
+
+**6-bit A/B (same date).** `mlx-community/GLM-4.7-Flash-6bit` (23.0 GB
+resident vs 30.0 GB): MLA probe PASS (+2.0 GB resident / +5.6 GB peak @ 15,959
+tokens); tool-calls 10/10 well-formed (mean 1.2 s vs 8-bit's 10/10 @ 1.8 s);
+sustained results in the matrix above. No fidelity regression observed on
+these probes; coding-quality delta not benchmarked.
 
 Note the outcome (date, oMLX version, pass/fail, measured numbers) in the PR or
 issue that prompted the re-run. If probe 1 fails, that is grounds to revisit


### PR DESCRIPTION
Records the 2026-07-04 measurement results for #22 and the #23 A/B probes in `docs/workhorse-probes.md` (new probe-3 section + banner note). Facts only — the config decision the numbers imply (concurrency flag, 6-bit adoption) is being decided separately and will land as its own change.

Key findings recorded:
- Sustained back-to-back N=10 @ ~16K distinct prefixes collapses admission (memory-enforcer dynamic-ceiling + prefix-cache-eviction spiral; HTTP 400 storms; 50/2,690 ok over 30 min). N=8 is sustained-clean on the 8-bit (~4 GB margin) and 6-bit (~8 GB margin).
- Saturation surfaces as HTTP 400 (`prefill memory guard rejected`) — routers must treat it as a capacity signal.
- No thermal throttling on the 16-inch chassis; system memory pressure never critical; RSS exceeded the guard (#702 behavior confirmed).
- 6-bit A/B: MLA probe PASS, tool calls 10/10, 23.0 GB resident.

Gates: markdownlint clean on the changed file (the one reported error is the pre-existing, git-ignored `.session-notes` fragment link, untouched here).

Note: PR #24 merged while these probes were running; this branch was cherry-picked onto the updated dev, and the stale `fix/ssd-cache-cap-and-citations` branch was deleted.