### PR TITLE
fix(templates): oMLX serves streaming usage — flip supportsUsageInStreaming

### DIFF
--- a/templates/pi-models-omlx.json
+++ b/templates/pi-models-omlx.json
@@ -10,7 +10,9 @@
 // compat flags for oMLX's OpenAI-completions endpoint:
 //   supportsDeveloperRole: false    — oMLX/Qwen do not accept the 'developer' role
 //   supportsReasoningEffort: false  — reasoning_effort is not implemented
-//   supportsUsageInStreaming: false — streaming usage stats not guaranteed
+//   supportsUsageInStreaming: true  — oMLX serves usage in the final stream chunk
+//                                     when stream_options.include_usage is requested
+//                                     (verified live 2026-07-05; psmfd/local-llm#34)
 //
 // Single workhorse model (ADR-009), addressed by its oMLX ALIAS (verified to
 // resolve on the installed version):
@@ -30,7 +32,7 @@
       "compat": {
         "supportsDeveloperRole": false,
         "supportsReasoningEffort": false,
-        "supportsUsageInStreaming": false
+        "supportsUsageInStreaming": true
       },
       "models": [
         {


### PR DESCRIPTION
Fixes #34 (close manually after merge if the keyword doesn't fire on dev).

One-line compat correction plus comment: oMLX **does** emit full usage in the final streaming chunk when `stream_options: {include_usage: true}` is requested — verified live against the running M5 server (`prompt_tokens`, `completion_tokens`, `prompt_tokens_details.cached_tokens`, perf metrics). pi-ai requests usage unless the flag is exactly `false` (`openai-completions.ts:556`), so the stale `false` here was zeroing every local turn in pi_config's measurement pipeline (pi_config#521).

The live `~/.pi/agent/models.json` was hand-patched to `true` on 2026-07-05 and verified (`{input:239, cacheRead:9728, output:29}` recorded on a workhorse turn); this PR reconciles the template so a future `--configure-pi` re-render doesn't regress it. Only file in the repo asserting the claim; no other consumer of the flag.