### PR TITLE
ci(upstream-watch): add 0.5.0 regression gate (omlx#2179/#2180), bump KNOWN_STABLE

### DIFF
--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -1,15 +1,19 @@
 name: upstream-watch
 
-# Weekly watch for the two upstream jundot/omlx events this repo is waiting on
+# Weekly watch for the upstream jundot/omlx events this repo is waiting on
 # (#30): a stable release newer than the pinned KNOWN_STABLE (gates the probe-3
-# re-run — #28), and closure of jundot/omlx#1835 (the macOS-27 long-context
-# regression — the host holds at macOS 26.x while it is open, see CLAUDE.md).
+# re-run — #28), closure of jundot/omlx#1835 (the macOS-27 long-context
+# regression — the host holds at macOS 26.x while it is open, see CLAUDE.md),
+# and clearance of the 0.5.0 regression gate — jundot/omlx#2179 (stuck prefill
+# token guard, no remote reset) and #2180 (failed LRU eviction discards a
+# reconstructed SSD prefix) — which holds the host at oMLX 0.4.4 (#39).
 # Each event files one tracking issue, deduped by a title search across open
 # AND closed issues so closing the tracking issue never re-triggers a duplicate.
 # This job is NOT a required check on any ruleset (adrs/007) — renaming it is
 # safe. Maintenance: bump KNOWN_STABLE after each handled release; remove or
-# repoint WATCHED_ISSUE once #1835 resolves; retire the workflow when nothing
-# is being watched.
+# repoint WATCHED_ISSUE once #1835 resolves; remove REGRESSION_GATE_ISSUES and
+# its step once the 0.4.4→0.5.x upgrade lands; retire the workflow when
+# nothing is being watched.
 
 on:
   schedule:
@@ -22,8 +26,9 @@ permissions:
 
 env:
   GH_TOKEN: ${{ github.token }}
-  KNOWN_STABLE: "0.4.4"
+  KNOWN_STABLE: "0.5.0"
   WATCHED_ISSUE: "1835"
+  REGRESSION_GATE_ISSUES: "2179 2180"
 
 jobs:
   upstream-watch:
@@ -108,3 +113,54 @@ jobs:
             --title "upstream watch: omlx#${WATCHED_ISSUE} (${marker}) closed — re-evaluate the macOS 26.x hold" \
             --body-file "${body_file}"
           echo "OK    [watch] filed tracking issue for omlx#${WATCHED_ISSUE}"
+
+      - name: Check the 0.5.0 regression gate (omlx#2179 + omlx#2180)
+        if: ${{ !cancelled() }}
+        run: |
+          set -euo pipefail
+          open_count=0
+          for n in ${REGRESSION_GATE_ISSUES}; do
+            state="$(gh api "repos/jundot/omlx/issues/${n}" --jq .state)"
+            echo "INFO  [gate ] jundot/omlx#${n} state: ${state}"
+            if [ "${state}" = "open" ]; then
+              open_count=$((open_count + 1))
+            fi
+          done
+          if [ "${open_count}" != "0" ]; then
+            echo "OK    [gate ] ${open_count} gate issue(s) still open — oMLX 0.4.4 hold stands (#39)"
+            exit 0
+          fi
+          marker="0.5.0 regression gate cleared"
+          count="$(gh issue list --repo "${GITHUB_REPOSITORY}" --state all \
+            --search "\"${marker}\" in:title" --json number --jq 'length')"
+          if [ "${count}" != "0" ]; then
+            echo "SKIP  [gate ] tracking issue already exists for the regression gate"
+            exit 0
+          fi
+          body_file="$(mktemp)"
+          cat > "${body_file}" <<EOF
+          The scheduled upstream watch (#30) detected that both 0.5.0
+          admission/eviction regressions holding the host at oMLX 0.4.4 —
+          jundot/omlx#2179 (prefill token guard fills with no remote reset)
+          and jundot/omlx#2180 (failed prefill LRU eviction discards a valid
+          reconstructed SSD prefix) — are now closed.
+
+          Next steps:
+
+          - Resume the deferred 0.4.4 → 0.5.x upgrade per the evaluation
+            checklist on #39: keg-preserving upgrade
+            (\`HOMEBREW_NO_INSTALL_CLEANUP=1\`), \`settings.json\` diff +
+            pin check, \`--validate\`, probe 4, and a probe-3 re-run
+            watching for a stuck (non-self-recovering) guard state.
+          - \`brew unpin jundot/omlx/omlx\` before upgrading (pinned while
+            the gate was open).
+          - Remove \`REGRESSION_GATE_ISSUES\` and this step from
+            \`.github/workflows/upstream-watch.yml\` once handled.
+
+          Upstream: https://github.com/jundot/omlx/issues/2179,
+          https://github.com/jundot/omlx/issues/2180
+          EOF
+          gh issue create --repo "${GITHUB_REPOSITORY}" \
+            --title "upstream watch: ${marker} (omlx#2179 + omlx#2180 closed) — resume the 0.4.4 → 0.5.x upgrade" \
+            --body-file "${body_file}"
+          echo "OK    [gate ] filed tracking issue for the cleared regression gate"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,10 @@ best-current-model review.
   `protect-dev`/`protect-main` rulesets — renaming a job breaks its ruleset binding
   (`007`). `upstream-watch.yml` is a weekly scheduled watch for upstream oMLX
   events (a stable release newer than its pinned `KNOWN_STABLE`; closure of
-  omlx#1835) that files idempotent tracking issues (#30) — not a required check. `.markdownlint-cli2.jsonc` configures the markdown step; `.shellcheckrc`
+  omlx#1835; clearance of the 0.5.0 regression gate omlx#2179/#2180, which
+  holds the host at oMLX 0.4.4 with the formula `brew pin`ned — the deferred
+  0.4.4 → 0.5.x upgrade is tracked in #39) that files idempotent tracking
+  issues (#30) — not a required check. `.markdownlint-cli2.jsonc` configures the markdown step; `.shellcheckrc`
   (both repo root) gates shellcheck at `severity=warning` so the intentional
   `A && B || true` / `((counter++)) || true` idioms (info-level SC2015) don't fail CI.
 - `adrs/` — `010-6bit-workhorse-sustained-mark.md` records the current quant


### PR DESCRIPTION
## Summary

Executes the interim follow-ups from the oMLX 0.4.4 → 0.5.0 upgrade evaluation (#39), which deferred the upgrade on two day-one 0.5.0 regressions in the admission/eviction path our sustained N=8 fan-out exercises:

- **omlx#2179 (BLOCKER):** prefill token guard fills with no remote reset — converts probe 3's self-recovering reject-loop into a stuck state requiring manual model unload.
- **omlx#2180:** failed prefill LRU eviction discards a valid reconstructed SSD prefix before confirming an evictable idle model exists → full re-prefill.

## Changes

- `.github/workflows/upstream-watch.yml`:
  - New weekly step **"Check the 0.5.0 regression gate"** — files one idempotent tracking issue (same dedup-by-title-marker pattern as the existing steps) once **both** omlx#2179 and omlx#2180 are closed, with the resume-the-upgrade checklist pointing back at #39.
  - `KNOWN_STABLE` 0.4.4 → **0.5.0** — the 0.5.0 release is handled (evaluated + tracked in #39); the next stable of interest is 0.5.1+.
  - Header comment updated with the new watch target and its removal condition.
- `CLAUDE.md`: workflow description updated in sync (gate, brew pin, #39 pointer).

## Host-side action taken alongside (not in this diff)

`brew pin jundot/omlx/omlx` — prevents a routine `brew upgrade` from silently pulling 0.5.0 in while the gate is open. The gate issue's checklist includes `brew unpin` before resuming the upgrade.

## Doc impact

| Surface | Classification | Reason |
| --- | --- | --- |
| CLAUDE.md workflow description | in-scope | updated in this PR |
| README `.github/workflows/` row | not-a-thing | generic "release/issue watch" wording still accurate |
| ADR | not-a-thing | pattern-following CI tweak under the existing upstream-watch precedent (#30/#32); the upgrade decision itself, if/when taken, is the ADR-eligible event |

## Verification

- linter agent: YAML valid, actionlint clean, shellcheck clean on all three embedded run blocks (`.shellcheckrc` gate and full severity), heredoc terminator semantics verified against Actions block-scalar stripping, markdownlint clean — **Verdict: PASS**.

Refs #39.
