### PR TITLE
fix(setup): correct stale 8-bit size figures; tighten CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,32 +4,38 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repository is
 
-A provisioning project — not an application. The goal is to stand up **oMLX**
+A provisioning project — not an application. It stands up **oMLX**
 (`jundot/omlx`) as a local, OpenAI/Anthropic-compatible inference server on an
 Apple Silicon **M5 Max (128 GB unified memory, macOS)**, tuned for a
 **parallel-agent coding workload**: an orchestrator fans out 3+ concurrent agent
 requests that share long system prefixes, so **concurrent throughput and
 prefix-cache reuse matter more than single-stream tok/s**.
 
-The authoritative brief is [`macos/local-llm-mac-os-creation.md`](macos/local-llm-mac-os-creation.md);
-the current model-lineup decision is [`adrs/009-mac-single-workhorse-cloud-frontier.md`](adrs/009-mac-single-workhorse-cloud-frontier.md)
-(the Mac is a **single-model subagent workhorse** — one pinned 3B-active MoE —
-with a **cloud provider as the quality frontier**; implemented via
-[#14](https://github.com/psmfd/local-llm/issues/14)), as amended by
-[`adrs/010-6bit-workhorse-sustained-mark.md`](adrs/010-6bit-workhorse-sustained-mark.md)
-(quant 8-bit → **6-bit** and concurrency mark 10 → **8**, from the sustained-load
-and A/B measurements in [#22](https://github.com/psmfd/local-llm/issues/22)/[#23](https://github.com/psmfd/local-llm/issues/23)).
-ADR-009 supersedes [`adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md`](adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md)
-(the three-tier lineup) and [`adrs/008-cross-host-routing-integration.md`](adrs/008-cross-host-routing-integration.md)
-(cross-host AMD routing; the appliance is repurposed/deprecated). ADR-002's
-`--memory-guard-gb` migration and wired limit, and ADR-001's oMLX runtime
-choice, carry forward unchanged; [`adrs/005-on-demand-service-lifecycle.md`](adrs/005-on-demand-service-lifecycle.md)
-(on-demand lifecycle) remains in force. The model-selection research is in
-[`docs/runtime-tiering-research.md`](docs/runtime-tiering-research.md); the
-one-time on-host probes (long-context MLA, `enable_thinking`) are in
-[`docs/workhorse-probes.md`](docs/workhorse-probes.md).
-`omlx-setup-prompt.md` is retained only as the historical source prompt; do not
-copy it forward as an additional source of truth.
+The current architecture: the Mac runs a **single pinned workhorse model** (one
+3B-active MoE), with a **cloud provider as the quality frontier** — decided in
+[`adrs/009-mac-single-workhorse-cloud-frontier.md`](adrs/009-mac-single-workhorse-cloud-frontier.md),
+as amended by [`adrs/010-6bit-workhorse-sustained-mark.md`](adrs/010-6bit-workhorse-sustained-mark.md)
+(quant 8-bit → **6-bit**, concurrency mark 10 → **8**).
+
+Decision history — each ADR's `Status:` front-matter carries the supersession
+chain; consult the ADRs rather than re-deriving it:
+
+- **ADR-009** supersedes ADR-006 (three-tier co-resident lineup) and ADR-008
+  (cross-host AMD routing; that appliance is repurposed — see
+  [`docs/amd-augmentation-research.md`](docs/amd-augmentation-research.md)).
+- **ADR-001** (oMLX runtime), **ADR-002** (`--memory-guard-gb` migration +
+  wired limit), **ADR-005** (on-demand lifecycle), and **ADR-007** (CI gate,
+  rulesets, deferred semantic-release) carry forward unchanged.
+
+The authoritative brief is
+[`macos/local-llm-mac-os-creation.md`](macos/local-llm-mac-os-creation.md);
+model-selection research is in
+[`docs/runtime-tiering-research.md`](docs/runtime-tiering-research.md); on-host
+probe results (long-context MLA, `enable_thinking`, sustained concurrency,
+Neural Accelerator engagement) are in
+[`docs/workhorse-probes.md`](docs/workhorse-probes.md). `omlx-setup-prompt.md`
+is retained only as the historical source prompt; do not copy it forward as an
+additional source of truth.
 
 ## Commands
 
@@ -43,6 +49,10 @@ The deliverable is `setup-omlx-m5.sh` (idempotent; author-side, run by the user)
 ./setup-omlx-m5.sh --verbose --help
 ```
 
+`--validate` short-circuits `main()`: it runs *only* the endpoint checks and
+exits — no preflight and no install steps run, even when combined with other
+flags.
+
 The server is **on-demand** (it does not start at login, and setup does not start
 it). Start/stop it intentionally with the installed `omlxctl` tool (ADR-005):
 
@@ -51,18 +61,34 @@ omlxctl start    # kickstart + wait for /health  |  omlxctl stop    # SIGTERM→
 omlxctl restart  # atomic restart + wait         |  omlxctl status  # launchd + /health state (warns on 0 models) |  omlxctl logs
 ```
 
-Exit codes: `0` pass, `1` errors, `2` precondition failure. Lint with the
-`linter` agent (shellcheck). The Metal wired-limit step needs `sudo`. The
-workhorse alias + pin is applied via the **oMLX admin API** (`apply_pins` briefly
-starts the server, PUTs the model's settings — and **unpins any retired ADR-006
-tiers** it finds registered — then stops it; `model_settings.json` is oMLX-owned,
-so the script never writes it directly); it degrades to printed manual
-admin-panel steps if the API can't be reached (ADR-009).
+Exit codes: `0` pass, `1` errors, `2` precondition failure. The Metal
+wired-limit step needs `sudo`. The workhorse alias + pin is applied via the
+**oMLX admin API** (`apply_pins` briefly starts the server, PUTs the model's
+settings — and **unpins any retired ADR-006 tiers** it finds registered, renaming
+the 8-bit to alias `workhorse-8b` so the primary alias transfers — then stops
+it; `model_settings.json` is oMLX-owned, so the script never writes it
+directly); it degrades to printed manual admin-panel steps if the API can't be
+reached (ADR-009).
 
 Preflight hard-fails with exit `2` for non-macOS, non-arm64, RAM below ~120 GB,
 free disk below ~90 GB, or missing Homebrew. M5 Max is the tuned target; a
 non-M5 Apple Silicon chip warns instead of hard-failing so nearby Max-class hosts
 can still smoke-test deliberately.
+
+### Local CI checks
+
+CI (`validate.yml`) runs three checks; reproduce them locally before pushing
+(use the `linter` agent for the shellcheck pass when available):
+
+```bash
+shellcheck --severity=warning setup-omlx-m5.sh templates/omlx-start-wrapper.sh templates/omlxctl
+markdownlint-cli2 "**/*.md"     # config auto-discovered from .markdownlint-cli2.jsonc
+# plist XML well-formedness: run the python3 stdlib check inline in validate.yml
+```
+
+`--severity=warning` (mirrored in `.shellcheckrc` for local runs) keeps the
+intentional info-level idioms (`A && B || true`, `((counter++)) || true`) from
+failing the gate.
 
 ## Hard constraints (project-specific)
 
@@ -80,42 +106,43 @@ can still smoke-test deliberately.
 
 The runtime and serving config are decided. **Re-verify the model choice and exact
 HuggingFace MLX repo IDs against current availability** before any download; if
-something better has shipped, propose it in the plan rather than substituting silently.
-The setup script also probes the configured Hugging Face repo IDs immediately
+something better has shipped, propose it in the plan rather than substituting
+silently. The setup script also probes the configured repo IDs immediately
 before `hf download`, but that existence check does not replace the operator's
 best-current-model review.
 
 - **Runtime:** oMLX via Homebrew —
-  `brew tap jundot/omlx https://github.com/jundot/omlx && brew install omlx`
+  `brew tap jundot/omlx https://github.com/jundot/omlx && brew install omlx`.
+  The formula is `brew pin`ned at the version tracked by `upstream-watch.yml`'s
+  `KNOWN_STABLE` while the 0.5.x regression gate holds (the deferred upgrade is
+  tracked in #39).
 - **Model (single workhorse, text-only; ADR-009 lineup, ADR-010 quant):**
   **`coding-workhorse`** — `mlx-community/GLM-4.7-Flash-6bit`
-  (`Glm4MoeLiteForCausalLM`, MoE ~3B active, 202K ctx, MLA KV compression —
-  verified on-host ≈ GQA footprint). ~24 GB (23.0 GB resident). Quality parity
-  with the 8-bit measured on-host (tool-calls 58/58 each; HumanEval 81.7% vs
-  80.5%, statistical tie — ADR-010). **Pinned, sole resident model.** A verified
-  text-only coder build (`*ForCausalLM`, no `vision_config`) and
-  tool-call-verified on oMLX, so it routes to the batched LLM engine with **no
-  engine override**. One pinned model gives the fan-out one shared prefix cache
-  and never exercises oMLX's multi-model swap path; under sustained N=8 fan-out
-  the measured footprint plateaus at ~78 GB with ~8 GB of margin to the
-  enforcer's hard threshold (`docs/workhorse-probes.md` probe 3). The DFlash speculative-decoding engine's private SSD
-  cache stays disabled (`dflash_ssd_cache=false`; DFlash itself is never engaged) —
-  the **main** SSD prefix cache (`--paged-ssd-cache-dir`) stays on; its live
-  upstream risk is oMLX #702 (the memory guard tracks Metal allocations, not
-  cache RSS).
-  **Retired models** (`GLM-4.7-Flash-8bit` — renamed to alias `workhorse-8b` on
-  unpin so the primary alias transfers — plus ADR-006's
+  (`Glm4MoeLiteForCausalLM`, MoE ~3B active, 202K ctx, MLA KV compression).
+  ~24 GB on disk. **Pinned, sole resident model** — one pinned model gives the
+  fan-out one shared prefix cache and never exercises oMLX's multi-model swap
+  path. A verified text-only coder build (`*ForCausalLM`, no `vision_config`)
+  and tool-call-verified on oMLX, so it routes to the batched LLM engine with
+  **no engine override**. Quality parity with the 8-bit and the measured
+  sustained-load footprint/margin are recorded in ADR-010 and
+  `docs/workhorse-probes.md` — cite those, don't restate the numbers. The
+  DFlash speculative-decoding engine's private SSD cache stays disabled
+  (`dflash_ssd_cache=false`; DFlash itself is never engaged) — the **main** SSD
+  prefix cache (`--paged-ssd-cache-dir`) stays on; its live upstream risk is
+  oMLX #702 (the memory guard tracks Metal allocations, not cache RSS).
+  **Retired models** (`GLM-4.7-Flash-8bit`, plus ADR-006's
   `Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` and `Qwen3-Coder-Next-MLX-4bit`) are
   never downloaded/aliased/validated; setup actively unpins them if a prior
-  install left them pinned. The **8-bit stays on disk as the primary inactive
-  fallback** (quality-parity-tested rollback: pin swap + restart), Qwen3-Coder-30B
-  as the secondary. GLM emits a reasoning preamble —
-  tool-bearing requests need `max_tokens ≥ ~200` (validation uses 256).
+  install left them pinned (see the `apply_pins` note under Commands). The
+  **8-bit stays on disk as the primary inactive fallback** (quality-parity-tested
+  rollback: pin swap + restart), Qwen3-Coder-30B as the secondary. GLM emits a
+  reasoning preamble — tool-bearing requests need `max_tokens ≥ ~200`
+  (validation uses 256).
 - **Serving flags:** `--host 127.0.0.1` (explicit loopback pin), port `8000`,
   `--memory-guard-gb 90` (replaces the removed `--max-process-memory`),
   `--paged-ssd-cache-dir ~/.omlx/cache`, `--paged-ssd-cache-max-size 50GB` (oMLX
   defaults the SSD tier to 100 GB — past the preflight's 90 GB free-disk budget;
-  50 GB keeps model + cache inside it with ~10 GB slack),
+  50 GB keeps model + cache inside it with ~16 GB slack),
   `--hot-cache-max-size 24GB` (oMLX accepts
   both absolute sizes and percentages; we pin an absolute value ≈ 27% of the guard
   for a deterministic footprint — one model, no second cache to fund),
@@ -127,9 +154,8 @@ best-current-model review.
   across reboot via a LaunchDaemon (sudo). The daemon stays loaded even when the
   server is stopped — it is a ceiling, not a reservation, and costs no memory idle.
 - **macOS floor and ceiling:** MLX engages the M5 GPU **Neural Accelerators**
-  only on **macOS ≥ 26.2** (verified engaged on-host 2026-07-05: the oMLX 0.4.4
-  brew keg bundles MLX 0.31.2; 57 TFLOPS fp16 GEMM — probe 4 in
-  `docs/workhorse-probes.md`, #27). Hold the host at **macOS 26.x** — do not
+  only on **macOS ≥ 26.2** (verified engaged on-host — probe 4 in
+  `docs/workhorse-probes.md`). Hold the host at **macOS 26.x** — do not
   upgrade to macOS 27 while jundot/omlx#1835 (10–15× long-context slowdown,
   suspected paged-cache-tier interaction) is open; re-run the probe suite after
   any macOS or oMLX upgrade.
@@ -137,8 +163,8 @@ best-current-model review.
   wrapper that carries the tuned flags (`brew services` only starts with zero-config
   defaults). The agent is `RunAtLoad=false` + `KeepAlive=false`, so login registers
   the job but never starts it, and a stop/crash stays down (no respawn; zero idle
-  footprint — the oMLX #15 GPU-hang crash loop that originally motivated this is
-  fixed upstream via PR #16; see the ADR-005 addendum). Start/stop is intentional via `omlxctl`
+  footprint — see the ADR-005 addendum for the crash-loop history that motivated
+  this). Start/stop is intentional via `omlxctl`
   (`kickstart` / `kill SIGTERM`→`SIGKILL` after 30s / `kickstart -k`); setup leaves
   the server stopped (ADR-005).
 
@@ -150,8 +176,7 @@ best-current-model review.
   demand, RunAtLoad=false) + the `omlxctl` control tool (symlinked onto PATH when
   the brew bin is writable); downloads the workhorse model when **download is
   opt-in (default off)**, skipping it if already present (upgrade-safe); applies
-  the alias + pin — and unpins retired ADR-006 tiers — via the admin API
-  (`apply_pins`, start→pin/unpin→stop) and leaves the server stopped;
+  the alias + pin via the admin API and leaves the server stopped;
   `--configure-pi` registers the provider with the Pi coding agent.
   No engine override step — the workhorse is text-only (ADR-009).
 - `templates/` — committed templates the script installs with placeholder
@@ -170,42 +195,27 @@ best-current-model review.
   - `apple-silicon-inference-expert` — Apple Silicon hardware/APIs: M-series
     CPU/GPU/ANE, unified memory, Metal/MPS, MLX, Core ML (the layer beneath oMLX;
     `omlx-expert` owns runtime specifics). Spec: `docs/inference-expert-agents.md`.
-- `.github/workflows/` — CI lint gate (`validate.yml`: shellcheck + markdownlint +
-  plist well-formedness; `lint-pr-title.yml`: Conventional Commits PR title). The
+- `.github/workflows/` — `validate.yml` (shellcheck + markdownlint + plist
+  well-formedness; see Local CI checks above), `lint-pr-title.yml` (Conventional
+  Commits PR title), and `upstream-watch.yml` (weekly watch for upstream oMLX
+  events that files idempotent tracking issues — not a required check). The
   `validate` and `lint-pr-title` job names are required-check contexts on the
-  `protect-dev`/`protect-main` rulesets — renaming a job breaks its ruleset binding
-  (`007`). `upstream-watch.yml` is a weekly scheduled watch for upstream oMLX
-  events (a stable release newer than its pinned `KNOWN_STABLE`; closure of
-  omlx#1835; clearance of the 0.5.0 regression gate omlx#2179/#2180, which
-  holds the host at oMLX 0.4.4 with the formula `brew pin`ned — the deferred
-  0.4.4 → 0.5.x upgrade is tracked in #39) that files idempotent tracking
-  issues (#30) — not a required check. `.markdownlint-cli2.jsonc` configures the markdown step; `.shellcheckrc`
-  (both repo root) gates shellcheck at `severity=warning` so the intentional
-  `A && B || true` / `((counter++)) || true` idioms (info-level SC2015) don't fail CI.
-- `adrs/` — `010-6bit-workhorse-sustained-mark.md` records the current quant
-  (6-bit) and sustained concurrency mark (8), amending
-  `009-mac-single-workhorse-cloud-frontier.md`, which records the lineup
-  (single pinned workhorse, cloud as frontier; implemented via #14),
-  superseding `006` (three-tier lineup — which superseded `004` → `003` → `002`
-  → `001`) and `008` (cross-host AMD routing). The `--memory-guard-gb`/wired-limit
-  from `002` and the oMLX runtime from `001` carry forward;
-  `005-on-demand-service-lifecycle.md` records the on-demand start/stop lifecycle
-  (no login autostart) — still in force under `009`;
-  `007-ci-rulesets-and-release-strategy.md` records the CI gate, branch-protection
-  rulesets, and the deferred-`semantic-release` decision; `TEMPLATE.md` is the
-  MADR minimal template for new ADRs (sequential, zero-padded three digits). The
-  model decision rationale lives in `docs/runtime-tiering-research.md`.
+  `protect-dev`/`protect-main` rulesets — renaming a job breaks its ruleset
+  binding (ADR-007). The workflow files carry their own config comments.
+- `adrs/` — decision records (MADR minimal template in `TEMPLATE.md`; sequential,
+  zero-padded three digits). ADR-009 + ADR-010 are the current lineup decision;
+  each file's `Status:` line carries the supersession chain (see "What this
+  repository is" above).
 - `docs/router-wiring.md` — wiring the server into the .NET `IInferenceBackend` /
   `FallbackInferenceRouter`.
 - `docs/workhorse-probes.md` — one-time on-host probes to run before trusting the
-  workhorse config under load (long-context MLA check, `enable_thinking`
-  pass-through).
-- `docs/amd-augmentation-research.md` — research note (2026-07-05) on reopening
-  the AMD RX 7900 XTX host as a **secondary augmentation** (not an ADR-008-style
-  routing peer): eval/CI farm first, overflow lane gated on the exact
-  guard-reject 400 (never Mac-unreachable), GLM-4.7-Flash disqualified on
-  gfx1100 (MLA is CDNA3-only in vLLM) — Qwen3-Coder-30B-A3B Q4 is the overflow
-  model. Assessment only; the decision record would be a new ADR amending 009.
+  workhorse config under load; re-run after any macOS or oMLX upgrade.
+- `docs/amd-augmentation-research.md` — research note on reopening the AMD
+  RX 7900 XTX host as a **secondary augmentation** (not an ADR-008-style routing
+  peer): eval/CI farm first, overflow lane gated on the exact guard-reject 400
+  (never Mac-unreachable), GLM-4.7-Flash disqualified on gfx1100 —
+  Qwen3-Coder-30B-A3B Q4 is the overflow model. Assessment only; the decision
+  record would be a new ADR amending 009.
 - `README.md` — the public-facing quickstart (clone → run → validate → connect).
   Keep it in sync when flags, model IDs, or the step order change.
 
@@ -221,13 +231,18 @@ each is idempotent (detects and skips what already exists). Templates in
 `templates/` are installed via `render_template`, which does literal placeholder
 substitution — edit the template file, not the rendered output.
 
+`check_omlx_cli()` probes `omlx serve --help` for every serving flag the wrapper
+uses before `install_service` will register the LaunchAgent; if any flag is
+missing (oMLX CLI drift), registration is **skipped entirely** with a recorded
+error — the first place to look when "why wasn't the LaunchAgent installed."
+
 ### Runtime artifacts (created on the host, never committed)
 
-- `~/.omlx/` (chmod 700) containing `api-key` (0600), `bin/omlx-start-wrapper.sh`,
-  `bin/omlxctl` (the on-demand control tool), `cache/`, `logs/`,
-  `pi-provider-snippet.json` (rendered by `--configure-pi`), and
-  `settings.json` (oMLX-managed; **contains a copy of the API key** at
-  `.auth.api_key` because oMLX persists its CLI args — the script chmods it 0600)
+- `~/.omlx/` (chmod 700) containing `api-key` (0600), `bin/` (start wrapper +
+  `omlxctl`), `cache/`, `logs/`, `pi-provider-snippet.json` (rendered by
+  `--configure-pi`), and `settings.json` — **oMLX-managed and it contains a copy
+  of the API key** at `.auth.api_key` because oMLX persists its CLI args; the
+  script chmods it 0600.
 - `$(brew --prefix)/bin/omlxctl` — symlink to `~/.omlx/bin/omlxctl`, created only
   when the brew bin is writable (otherwise the script prints the manual `ln`/PATH step)
 - `~/models/` — downloaded MLX model directories

--- a/setup-omlx-m5.sh
+++ b/setup-omlx-m5.sh
@@ -12,7 +12,7 @@
 #   ./setup-omlx-m5.sh [options]
 #
 # Options:
-#   --download-model   Download the coding-workhorse model (~30 GB) via
+#   --download-model   Download the coding-workhorse model (~24 GB) via
 #                      `hf download`. Off by default. Retired ADR-006 tiers are
 #                      never downloaded. Existing model dirs are skipped (never
 #                      re-downloaded or deleted), so this is safe to re-run when

--- a/templates/omlx-start-wrapper.sh
+++ b/templates/omlx-start-wrapper.sh
@@ -66,7 +66,7 @@ fi
 # from ADR-006's 18GB: one model, no second cache to fund; ADR-009).
 # --paged-ssd-cache-max-size caps the SSD tier of the prefix cache; left unset,
 # oMLX defaults it to 100GB — past the setup preflight's 90 GB free-disk budget.
-# 50GB keeps model (~30 GB) + SSD cache inside that budget with ~10 GB slack.
+# 50GB keeps model (~24 GB) + SSD cache inside that budget with ~16 GB slack.
 # --max-concurrent-requests 8 is ADR-010's SUSTAINED Mark: 10 was clean as a
 # single burst (ADR-009) but collapses under back-to-back fan-out — the memory
 # enforcer's dynamic ceiling drops and it evicts the prefix cache, producing an


### PR DESCRIPTION
## What

- **Reconcile model-size figures to the 6-bit workhorse (ADR-010):** `setup-omlx-m5.sh` `--help` text and the start-wrapper disk-budget comment still said **~30 GB** — the retired 8-bit quant's size — after the ADR-010 swap. Both now say **~24 GB**, and the wrapper's derived slack arithmetic is corrected from ~10 GB to **~16 GB** (90 GB budget − 24 GB model − 50 GB SSD cache), with the matching CLAUDE.md figure updated.
- **CLAUDE.md gap-fill:** adds a Local CI checks block mirroring `validate.yml` (shellcheck / markdownlint-cli2 / plist check), documents that `--validate` short-circuits `main()` (validation only, no preflight/install), and documents the `check_omlx_cli()` gate that skips LaunchAgent registration on oMLX CLI flag drift.
- **CLAUDE.md trims (no information loss):** the ADR supersession chain is narrated once (intro) instead of three times; restated measurements (HumanEval scores, tool-call counts, footprint plateau, TFLOPS, probe dates, bundled MLX version) become citations to ADR-010 / `docs/workhorse-probes.md` / `upstream-watch.yml`'s `KNOWN_STABLE`; the retired-models unpin mechanic is stated once; ADR citations preferred over issue numbers for settled facts.

## Why

Found during a `/init` verification pass: a three-agent audit (script-claims verification, repo drift sweep, doc-quality review) confirmed CLAUDE.md accurate except for the 24-vs-30 GB inconsistency, which traced into the script's own `--help` text — a stale leftover from the 8-bit → 6-bit swap. ADR-010 ("6-bit is 23.0 GB resident vs 30.0 GB") is the authoritative figure.

## Doc-impact

| Surface | Classification | Reason |
|---|---|---|
| `setup-omlx-m5.sh`, `templates/omlx-start-wrapper.sh`, `CLAUDE.md` | in-scope | changed here |
| `README.md` | not-a-thing | already accurate at ~24 GB; no flag/model/step-order change |
| ADR | not-a-thing | doc-accuracy fix, no convention change |

## Verification

- `shellcheck --severity=warning` clean on all three scripts
- `markdownlint-cli2 "**/*.md"` — CLAUDE.md clean (sole error is in gitignored `.session-notes/`, absent from CI checkouts)
- Templates' plists untouched