### PR TITLE
chore(upstream): land oMLX 0.5.3, retire the 0.5.0 regression gate, record the re-baseline

### DIFF
--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -1,19 +1,17 @@
 name: upstream-watch
 
 # Weekly watch for the upstream jundot/omlx events this repo is waiting on
-# (#30): a stable release newer than the pinned KNOWN_STABLE (gates the probe-3
-# re-run — #28), closure of jundot/omlx#1835 (the macOS-27 long-context
-# regression — the host holds at macOS 26.x while it is open, see CLAUDE.md),
-# and clearance of the 0.5.0 regression gate — jundot/omlx#2179 (stuck prefill
-# token guard, no remote reset) and #2180 (failed LRU eviction discards a
-# reconstructed SSD prefix) — which holds the host at oMLX 0.4.4 (#39).
+# (#30): a stable release newer than the pinned KNOWN_STABLE (gates a probe-3
+# re-run before any upgrade is trusted) and closure of jundot/omlx#1835 (the
+# macOS-27 long-context regression — the host holds at macOS 26.x while it is
+# open, see CLAUDE.md). The 0.5.0 regression-gate step was removed after the
+# 0.4.4→0.5.3 upgrade landed (omlx#2179/#2180 fixed in 0.5.2/0.5.1).
 # Each event files one tracking issue, deduped by a title search across open
 # AND closed issues so closing the tracking issue never re-triggers a duplicate.
 # This job is NOT a required check on any ruleset (adrs/007) — renaming it is
 # safe. Maintenance: bump KNOWN_STABLE after each handled release; remove or
-# repoint WATCHED_ISSUE once #1835 resolves; remove REGRESSION_GATE_ISSUES and
-# its step once the 0.4.4→0.5.x upgrade lands; retire the workflow when
-# nothing is being watched.
+# repoint WATCHED_ISSUE once #1835 resolves; retire the workflow when nothing
+# is being watched.
 
 on:
   schedule:
@@ -26,9 +24,8 @@ permissions:
 
 env:
   GH_TOKEN: ${{ github.token }}
-  KNOWN_STABLE: "0.5.0"
+  KNOWN_STABLE: "0.5.3"
   WATCHED_ISSUE: "1835"
-  REGRESSION_GATE_ISSUES: "2179 2180"
 
 jobs:
   upstream-watch:
@@ -61,9 +58,9 @@ jobs:
 
           Next steps:
 
-          - Re-run \`docs/workhorse-probes.md\` probe 3 per #28 (the 0.4.5
-            line ships a Memory Guard threshold retune that can move the
-            sustained-safe concurrency mark).
+          - Re-run \`docs/workhorse-probes.md\` probe 3 before trusting the
+            upgrade (upstream Memory Guard retunes can move the sustained-safe
+            concurrency mark and the prefill-guard ceiling).
           - Bump \`KNOWN_STABLE\` in \`.github/workflows/upstream-watch.yml\`
             once handled.
 
@@ -113,54 +110,3 @@ jobs:
             --title "upstream watch: omlx#${WATCHED_ISSUE} (${marker}) closed — re-evaluate the macOS 26.x hold" \
             --body-file "${body_file}"
           echo "OK    [watch] filed tracking issue for omlx#${WATCHED_ISSUE}"
-
-      - name: Check the 0.5.0 regression gate (omlx#2179 + omlx#2180)
-        if: ${{ !cancelled() }}
-        run: |
-          set -euo pipefail
-          open_count=0
-          for n in ${REGRESSION_GATE_ISSUES}; do
-            state="$(gh api "repos/jundot/omlx/issues/${n}" --jq .state)"
-            echo "INFO  [gate ] jundot/omlx#${n} state: ${state}"
-            if [ "${state}" = "open" ]; then
-              open_count=$((open_count + 1))
-            fi
-          done
-          if [ "${open_count}" != "0" ]; then
-            echo "OK    [gate ] ${open_count} gate issue(s) still open — oMLX 0.4.4 hold stands (#39)"
-            exit 0
-          fi
-          marker="0.5.0 regression gate cleared"
-          count="$(gh issue list --repo "${GITHUB_REPOSITORY}" --state all \
-            --search "\"${marker}\" in:title" --json number --jq 'length')"
-          if [ "${count}" != "0" ]; then
-            echo "SKIP  [gate ] tracking issue already exists for the regression gate"
-            exit 0
-          fi
-          body_file="$(mktemp)"
-          cat > "${body_file}" <<EOF
-          The scheduled upstream watch (#30) detected that both 0.5.0
-          admission/eviction regressions holding the host at oMLX 0.4.4 —
-          jundot/omlx#2179 (prefill token guard fills with no remote reset)
-          and jundot/omlx#2180 (failed prefill LRU eviction discards a valid
-          reconstructed SSD prefix) — are now closed.
-
-          Next steps:
-
-          - Resume the deferred 0.4.4 → 0.5.x upgrade per the evaluation
-            checklist on #39: keg-preserving upgrade
-            (\`HOMEBREW_NO_INSTALL_CLEANUP=1\`), \`settings.json\` diff +
-            pin check, \`--validate\`, probe 4, and a probe-3 re-run
-            watching for a stuck (non-self-recovering) guard state.
-          - \`brew unpin jundot/omlx/omlx\` before upgrading (pinned while
-            the gate was open).
-          - Remove \`REGRESSION_GATE_ISSUES\` and this step from
-            \`.github/workflows/upstream-watch.yml\` once handled.
-
-          Upstream: https://github.com/jundot/omlx/issues/2179,
-          https://github.com/jundot/omlx/issues/2180
-          EOF
-          gh issue create --repo "${GITHUB_REPOSITORY}" \
-            --title "upstream watch: ${marker} (omlx#2179 + omlx#2180 closed) — resume the 0.4.4 → 0.5.x upgrade" \
-            --body-file "${body_file}"
-          echo "OK    [gate ] filed tracking issue for the cleared regression gate"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,8 +114,9 @@ best-current-model review.
 - **Runtime:** oMLX via Homebrew —
   `brew tap jundot/omlx https://github.com/jundot/omlx && brew install omlx`.
   The formula is `brew pin`ned at the version tracked by `upstream-watch.yml`'s
-  `KNOWN_STABLE` while the 0.5.x regression gate holds (the deferred upgrade is
-  tracked in #39).
+  `KNOWN_STABLE` (0.5.3 — upgraded 2026-07-28 after the 0.5.0 regression gate
+  cleared; the 0.4.4 keg is retained for rollback). Re-run the probe suite
+  before trusting any future bump.
 - **Model (single workhorse, text-only; ADR-009 lineup, ADR-010 quant):**
   **`coding-workhorse`** — `mlx-community/GLM-4.7-Flash-6bit`
   (`Glm4MoeLiteForCausalLM`, MoE ~3B active, 202K ctx, MLA KV compression).

--- a/docs/workhorse-probes.md
+++ b/docs/workhorse-probes.md
@@ -21,6 +21,22 @@ deliberately avoid.
 > M5 Neural Accelerators engaged by the Homebrew build: 57.0 TFLOPS fp16 /
 > 57.1 TFLOPS bf16 on the GEMM probe (~3× plain-shader class). The oMLX
 > v0.2.19 "must use the `macos26-tahoe` DMG" guidance is stale at 0.4.4 (#27).
+>
+> **0.5.3 re-baseline: 2026-07-28, oMLX 0.5.3 (MLX 0.32.0), macOS 26.5.2 —
+> probes 3 + 4 PASS; prefill-ladder re-measured** (post-upgrade run for
+> #56/#39; see the "0.5.3 re-baseline" subsections under probes 3 and 4).
+> Highlights: probe 4 unchanged at 57.4/57.3 TFLOPS; sustained mark 4 ran an
+> incident-shaped load (8×~28.3K-token cold streams) clean — 16/16, zero guard
+> rejects; the guard's idle dynamic ceiling rose 66 → **73.08 GB** and the
+> single-prefill acceptance boundary moved ~84K → **~98K tokens** (81K
+> accepted outright), so ADR-011's `contextWindow 76800` and ADR-012's mark 4
+> stand with *more* margin — no config change. TurboQuant KV compression is
+> **off** for the workhorse (`turboquant_kv_bits=None`), so the slope stays
+> comparable across versions. One contract change: an over-boundary prompt now
+> surfaces as an **HTTP 200 "JSON keepalive prefill rejected"** error after a
+> multi-minute stall, not the 0.4.4 instant 400 — router/pi handling tracked
+> in #58. The 0.5.1 SSD-cache re-keying invalidated the on-disk prefix cache
+> once (4,974 blocks / 65.77 GB skipped at first scan) — expected, one-time.
 
 Prereqs: server provisioned, `omlxctl start` done, `KEY="$(cat ~/.omlx/api-key)"`.
 
@@ -146,6 +162,65 @@ tokens); tool-calls 10/10 well-formed (mean 1.2 s vs 8-bit's 10/10 @ 1.8 s);
 sustained results in the matrix above. No fidelity regression observed on
 these probes; coding-quality delta not benchmarked.
 
+### 0.5.3 re-baseline (2026-07-28, mark 4, MLX 0.32.0, macOS 26.5.2)
+
+Post-upgrade re-run for #56/#39 after the 0.5.2 memory-guard retune
+("eviction now starts at the soft watermark" + #2179 pooled-buffer
+self-recovery) invalidated the 0.4.4-fit constants.
+
+**Sustained run (harsher than canonical).** The generated prefixes tokenized
+to **~28.3K tokens** (not the canonical ~16K), so the run reproduced the
+2026-07-26 incident shape directly: back-to-back waves of 8 concurrent unique
+cold ~28.3K prompts (server admits 4, queues 4; `max_tokens` 300), ~13 min.
+Result: **16/16 ok, zero guard 400s, zero `adaptive_prefill_throttle` /
+eviction lines**, footprint plateau ~63 GB, host memory pressure normal.
+The mark-8 failure mode (400 storm + cache-evict spiral) did not reproduce at
+mark 4 on 0.5.3. Per-stream decode collapsed to ~0.8–1.6 tok/s while
+concurrent prefills ran — the head-of-line fairness issue tracked in #45, not
+a regression. Wave wall time ~372–390 s for 8×28.3K cold streams.
+
+**Prefill ladder (pi_config#889 method, fresh restart, single stream, unique
+cache-busting payloads).** Accepted rungs, wall time and process footprint
+(peak is cumulative):
+
+| Prompt tokens | Wall time | Footprint cur → peak |
+| --- | --- | --- |
+| 8,161 | 4.3 s | 23.8 → 27.5 GB |
+| 16,249 | 12.2 s | 24.6 → 29.8 GB |
+| 32,496 | 42.5 s | 26.4 → 36.2 GB |
+| 48,648 | 93.8 s | 29.0 → 44.0 GB |
+| 64,898 | 169.7 s | 32.6 → 52.7 GB |
+| 72,905 | 213.2 s | 36.7 → 59.4 GB |
+| 81,105 | 263.8 s | 41.2 → 66.5 GB |
+
+The ~88K and ~96K rungs were **rejected by the guard** — but on 0.5.3 the
+rejection is no longer an instant pre-compute 400: the scheduler paused the
+request (`adaptive_prefill_throttle`), ran the 0.5.2 pooled-buffer reclaim
+(recovered only 2.58/3.27 GB, "no idle model to evict"), then rejected ~5 min
+in as an **HTTP 200 "JSON keepalive prefill rejected"** error body with no
+`usage` (guard lines: "~91.83 GB peak (current 53.17 GB + KV+SDPA 38.65 GB)
+but dynamic ceiling is 73.08 GB"). Client-side capacity detection must handle
+both paths — tracked in #58.
+
+**Derived constants (0.5.3), vs ADR-011's 0.4.4 fit:**
+
+- Guard dynamic ceiling at idle: **73.08 GB** (was 66 GB).
+- Guard estimator slope: **~0.44 GB/1K tokens** (88K rung: 38.65 GB; 96K rung:
+  42.25 GB — effectively unchanged from 0.433). Actual per-rung footprint cost
+  measured lower (~0.37 GB/1K), i.e. the estimator is conservative.
+- Fresh-idle acceptance boundary: **~98K tokens** by ADR-011's formula
+  `(ceiling − current≈30 GB) / slope` (was ~84K); 81K accepted outright.
+- **Caveat:** retained prefix cache grew guard "current" from ~30 GB to
+  **53.17 GB** over the ladder, shrinking the *effective* boundary to ~45K
+  under long uptimes with a hot cache — throttle-time reclaim recovered only
+  ~3 GB. The advertised window must keep margin for this, not just for host
+  load.
+
+**Config consequence: none.** `contextWindow 76800` is ~78% of the new idle
+boundary (was ~91% of the old) and the wall-time cliff (264 s at 81K) still
+argues against inviting larger contexts; mark 4 ran the incident shape clean.
+ADR-011/012 stand re-affirmed with wider margin — no amendment needed.
+
 ## 4. M5 Neural Accelerator engagement probe
 
 **Why.** MLX exploits the M5 GPU's Neural Accelerators (dedicated matmul units;
@@ -199,10 +274,12 @@ numbers despite both version gates passing → the installed build is not
 engaging the accelerators; check how the keg was built (brew tap vs DMG) and
 the bundled mlx version before touching serving config.
 
-**Last run (2026-07-05, oMLX 0.4.4 brew keg, MLX 0.31.2, macOS 26.5.1):**
-57.0 TFLOPS fp16 / 57.1 TFLOPS bf16 — PASS. Re-run after any oMLX upgrade
-(the bundled MLX can move) and after any macOS update (see also the macOS-27
-hold: jundot/omlx#1835).
+**Last run (2026-07-28, oMLX 0.5.3 brew keg, MLX 0.32.0, macOS 26.5.2):**
+57.4 TFLOPS fp16 / 57.3 TFLOPS bf16 — PASS. The 0.5.0 "NAX-aware dispatch"
+change did not move the M5 Max GEMM baseline (2026-07-05 on 0.4.4 / MLX
+0.31.2: 57.0 / 57.1). Re-run after any oMLX upgrade (the bundled MLX can
+move) and after any macOS update (see also the macOS-27 hold:
+jundot/omlx#1835).
 
 Note the outcome (date, oMLX version, pass/fail, measured numbers) in the PR or
 issue that prompted the re-run. If probe 1 fails, that is grounds to revisit


### PR DESCRIPTION
## Summary

The 0.5.0 regression gate cleared (omlx#2179 fixed in 0.5.2 via PR #2306, omlx#2180 fixed in 0.5.1) and the 0.4.4 → **0.5.3** upgrade was executed on the host 2026-07-28 per the #56/#39 checklists. This PR lands the repo-side follow-through.

## Host upgrade evidence (Part B of the approved plan)

- Keg-preserving upgrade (`HOMEBREW_NO_INSTALL_CLEANUP=1`); **0.4.4 keg retained** for rollback; formula re-pinned at 0.5.3. Bundled MLX 0.31.2 → 0.32.0.
- `~/.omlx/settings.json` byte-identical pre/post, still 0600; `coding-workhorse` alias + pin survived.
- `check_omlx_cli`: no serve-flag drift; setup re-run PASS 0 errors; `--validate` **9/9 PASS**.
- **Probe 4** PASS: 57.4/57.3 TFLOPS (baseline 57.0/57.1) — NAX still engaged.
- **Probe 3** (harsher-than-canonical: 8 concurrent ~28.3K-token cold streams — the 2026-07-26 incident shape) ran **clean at mark 4**: 16/16, zero guard rejects, zero throttle/eviction, ~63 GB plateau.
- **Prefill ladder** re-measured: guard ceiling 66 → **73.08 GB**, estimator slope ~0.44 GB/1K (unchanged), fresh-idle boundary ~84K → **~98K tokens** (81K accepted). TurboQuant off (`turboquant_kv_bits=None`) so figures are comparable. Full data in `docs/workhorse-probes.md`.
- **Config consequence: none** — `contextWindow 76800` / mark 4 (ADR-011/012) stand re-affirmed with wider margin, so no ADR-013 (pattern-following per the approved plan's conditional).
- `omlxctl` supervision works on 0.5.3: launchd tracks the real server PID, `stop`/`restart` behave — resolving the 0.4.4 detach bug.

## Changes

- `.github/workflows/upstream-watch.yml` — `KNOWN_STABLE` 0.5.0 → 0.5.3; `REGRESSION_GATE_ISSUES` env + gate step removed (per the file's own maintenance comment); header + release-issue template updated.
- `docs/workhorse-probes.md` — 2026-07-28 re-baseline recorded (header note, probe-3 subsection with sustained + ladder data and derived constants, probe-4 last-run refresh).
- `CLAUDE.md` — brew-pin sentence updated (pinned at KNOWN_STABLE 0.5.3, gate retired, 0.4.4 rollback keg noted).

## Doc impact

| Surface | Classification | Reason |
| --- | --- | --- |
| upstream-watch.yml comments | in-scope | gate removal + KNOWN_STABLE bump |
| docs/workhorse-probes.md | in-scope | re-baseline results |
| CLAUDE.md pin note | in-scope | pin policy wording |
| ADR | not-a-thing | no config/decision change — ADR-011/012 re-affirmed; recorded in probes doc |
| docs/router-wiring.md keepalive-reject note | out-of-scope, tracked | #58 (belongs with the router-side handling change) |

## Follow-ups

- #58 (filed from this work): 0.5.3 surfaces over-boundary guard rejects as HTTP 200 keepalive-JSON errors — router/pi capacity detection must cover both paths.
- #45 stays open: chunked-prefill evaluation now has its new baseline to run against (per-stream decode starvation during concurrent prefill reconfirmed).

## Validation

- markdownlint-cli2 PASS (CLAUDE.md, workhorse-probes.md); YAML parse OK on the workflow; self-review clean.

Closes #56, closes #55, closes #47, closes #39, closes #28, closes #41