### PR TITLE
feat(workhorse)!: adopt gpt-oss-120b serial workhorse (ADR-013)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,21 +7,26 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 A provisioning project — not an application. It stands up **oMLX**
 (`jundot/omlx`) as a local, OpenAI/Anthropic-compatible inference server on an
 Apple Silicon **M5 Max (128 GB unified memory, macOS)**, tuned for a
-**parallel-agent coding workload**: an orchestrator fans out 3+ concurrent agent
-requests that share long system prefixes, so **concurrent throughput and
-prefix-cache reuse matter more than single-stream tok/s**.
+**serial workflow coding workload**: one request in flight at a time, each
+step's output feeding the next as a growing transcript, so **single-stream
+decode, prefill speed, and turn-over-turn prefix-cache reuse matter — there is
+no concurrent fan-out** (ADR-013 retired the ADR-009-era parallel premise).
 
-The current architecture: the Mac runs a **single pinned workhorse model** (one
-3B-active MoE), with a **cloud provider as the quality frontier** — decided in
+The current architecture: the Mac runs a **single pinned workhorse model**
+(gpt-oss-120b-4bit, a 5.1B-active MoE), with a **cloud provider as the quality
+frontier** — structure decided in
 [`adrs/009-mac-single-workhorse-cloud-frontier.md`](adrs/009-mac-single-workhorse-cloud-frontier.md),
-as amended by [`adrs/010-6bit-workhorse-sustained-mark.md`](adrs/010-6bit-workhorse-sustained-mark.md)
-(quant 8-bit → **6-bit**),
-[`adrs/011-pi-context-window-guard-boundary.md`](adrs/011-pi-context-window-guard-boundary.md)
-(pi-advertised contextWindow 131072 → **76800**, the measured prefill-guard
-boundary), and
-[`adrs/012-concurrency-mark-4-large-context.md`](adrs/012-concurrency-mark-4-large-context.md)
-(concurrency mark 8 → **4** and pi maxTokens 16384 → **8192** for
-large-context agentic load).
+model and serial serving shape decided in
+[`adrs/013-gptoss-serial-workhorse.md`](adrs/013-gptoss-serial-workhorse.md)
+(workhorse GLM-4.7-Flash-6bit → **gpt-oss-120b-4bit**, concurrency mark 4 →
+**1**, pi contextWindow 76800 → **122880**; evidence in
+[#73](https://github.com/psmfd/local-llm/issues/73)). The GLM-era amendments —
+[`adrs/010`](adrs/010-6bit-workhorse-sustained-mark.md) (6-bit quant),
+[`adrs/011`](adrs/011-pi-context-window-guard-boundary.md) (guard-bound
+contextWindow), [`adrs/012`](adrs/012-concurrency-mark-4-large-context.md)
+(mark 4, maxTokens 8192) — are amended by ADR-013; only the maxTokens 8192
+decision carries forward, and the GLM-6bit configuration they describe remains
+the documented primary-fallback rollback.
 
 Decision history — each ADR's `Status:` front-matter carries the supersession
 chain; consult the ADRs rather than re-deriving it:
@@ -49,7 +54,7 @@ The deliverable is `setup-omlx-m5.sh` (idempotent; author-side, run by the user)
 
 ```bash
 ./setup-omlx-m5.sh                  # preflight + install + dirs + key + wired-limit + service + omlxctl (no model download; server NOT started)
-./setup-omlx-m5.sh --download-model # also fetch the workhorse model (~24 GB) via hf
+./setup-omlx-m5.sh --download-model # also fetch the workhorse model (~66 GB) via hf
 ./setup-omlx-m5.sh --configure-pi   # register the oMLX provider with the Pi coding agent (~/.pi/agent/models.json)
 ./setup-omlx-m5.sh --validate       # endpoint checks (models / chat / tool-call / Anthropic / 2-way concurrency / effective cache mode) against a running server
 ./setup-omlx-m5.sh --verbose --help
@@ -57,7 +62,7 @@ The deliverable is `setup-omlx-m5.sh` (idempotent; author-side, run by the user)
 
 `--validate` short-circuits `main()`: it runs *only* the endpoint checks and
 exits — no preflight and no install steps run, even when combined with other
-flags.
+flags. (`--download-model` now fetches ~66 GB — the gpt-oss workhorse.)
 
 The server is **on-demand** (it does not start at login, and setup does not start
 it). Start/stop it intentionally with the installed `omlxctl` tool (ADR-005):
@@ -70,11 +75,11 @@ omlxctl restart  # atomic restart + wait         |  omlxctl status  # launchd + 
 Exit codes: `0` pass, `1` errors, `2` precondition failure. The Metal
 wired-limit step needs `sudo`. The workhorse alias + pin is applied via the
 **oMLX admin API** (`apply_pins` briefly starts the server, PUTs the model's
-settings — and **unpins any retired ADR-006 tiers** it finds registered, renaming
-the 8-bit to alias `workhorse-8b` so the primary alias transfers — then stops
-it; `model_settings.json` is oMLX-owned, so the script never writes it
-directly); it degrades to printed manual admin-panel steps if the API can't be
-reached (ADR-009).
+settings — and **unpins any retired tiers** it finds registered, renaming the
+GLM-6bit to alias `workhorse-glm` (and the 8-bit to `workhorse-8b`) so the
+primary alias transfers to gpt-oss — then stops it; `model_settings.json` is
+oMLX-owned, so the script never writes it directly); it degrades to printed
+manual admin-panel steps if the API can't be reached (ADR-009/013).
 
 Preflight hard-fails with exit `2` for non-macOS, non-arm64, RAM below ~120 GB,
 free disk below ~90 GB, or missing Homebrew. M5 Max is the tuned target; a
@@ -126,45 +131,52 @@ best-current-model review.
   `$(brew --repository jundot/omlx)`, then `brew reinstall omlx`). Re-run the
   probe suite
   before trusting any future bump.
-- **Model (single workhorse, text-only; ADR-009 lineup, ADR-010 quant):**
-  **`coding-workhorse`** — `mlx-community/GLM-4.7-Flash-6bit`
-  (`Glm4MoeLiteForCausalLM`, MoE ~3B active, 202K ctx, MLA KV compression).
-  ~24 GB on disk. **Pinned, sole resident model** — one pinned model gives the
-  fan-out one shared prefix cache and never exercises oMLX's multi-model swap
-  path. A verified text-only coder build (`*ForCausalLM`, no `vision_config`)
-  and tool-call-verified on oMLX, so it routes to the batched LLM engine with
-  **no engine override**. Quality parity with the 8-bit and the measured
-  sustained-load footprint/margin are recorded in ADR-010 and
-  `docs/workhorse-probes.md` — cite those, don't restate the numbers. The
-  DFlash speculative-decoding engine's private SSD cache stays disabled
-  (`dflash_ssd_cache=false`; DFlash itself is never engaged) — the **main** SSD
-  prefix cache (`--paged-ssd-cache-dir`) stays on; its live upstream risk is
-  oMLX #702 (the memory guard tracks Metal allocations, not cache RSS).
-  **Retired models** (`GLM-4.7-Flash-8bit`, plus ADR-006's
+- **Model (single workhorse, text-only; ADR-009 structure, ADR-013 model):**
+  **`coding-workhorse`** — `mlx-community/gpt-oss-120b-4bit`
+  (`GptOssForCausalLM`, MoE 117B total / 5.1B active, native 131,072 ctx,
+  alternating sliding-window(128)/full attention, 8-head GQA — KV
+  ~0.070 GB/1K). ~66 GB on disk (61.56 GB resident measured). **Pinned, sole
+  resident model** — never exercises oMLX's multi-model swap path. A verified
+  text-only build (`*ForCausalLM`, no `vision_config`) routed to the batched
+  LLM engine with **no engine override**; Harmony tool calling verified 58/58
+  on oMLX 0.5.7, HumanEval 95.7% vs the GLM incumbent's 83.5% (McNemar
+  p=0.00018), and a 4-hour serial soak clean — all recorded in ADR-013 and
+  [#73](https://github.com/psmfd/local-llm/issues/73); cite those, don't
+  restate the numbers. The DFlash speculative-decoding engine stays disengaged
+  (`dflash_ssd_cache=false`; no DFlash draft exists for either the current or
+  the fallback workhorse — #71) — the **main** SSD prefix cache
+  (`--paged-ssd-cache-dir`) stays on; its live upstream risk is oMLX #702
+  (the memory guard tracks Metal allocations, not cache RSS). **Retired
+  models** (`GLM-4.7-Flash-6bit`, `GLM-4.7-Flash-8bit`, plus ADR-006's
   `Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` and `Qwen3-Coder-Next-MLX-4bit`) are
   never downloaded/aliased/validated; setup actively unpins them if a prior
   install left them pinned (see the `apply_pins` note under Commands). The
-  **8-bit stays on disk as the primary inactive fallback** (quality-parity-tested
-  rollback: pin swap + restart), Qwen3-Coder-30B as the secondary. GLM emits a
-  reasoning preamble — tool-bearing requests need `max_tokens ≥ ~200`
-  (validation uses 256).
+  **GLM-6bit stays on disk as the primary inactive fallback** (full ADR-009/010
+  probe history; rollback = pin swap + restore GLM-era flags + restart — and
+  restoring parallel fan-out serving requires exactly this rollback, since
+  gpt-oss's weights leave no multi-stream KV pool). gpt-oss emits a Harmony
+  reasoning channel before answers/tool calls — tool-bearing requests need
+  generous `max_tokens` (validation uses 512); reasoning effort is controlled
+  via `chat_template_kwargs: {"reasoning_effort": "low|medium|high"}` (default
+  medium — the top-level `reasoning_effort` param is **ignored** by oMLX
+  0.5.7; client delivery via pi payload-tuner, pi_config#1052).
 - **Serving flags:** `--host 127.0.0.1` (explicit loopback pin), port `8000`,
   `--memory-guard-gb 90` (replaces the removed `--max-process-memory`),
-  `--paged-ssd-cache-dir ~/.omlx/cache`, `--paged-ssd-cache-max-size 50GB` (oMLX
-  defaults the SSD tier to 100 GB — past the preflight's 90 GB free-disk budget;
-  50 GB keeps model + cache inside it with ~16 GB slack),
-  `--hot-cache-max-size 24GB` (oMLX accepts
-  both absolute sizes and percentages; we pin an absolute value ≈ 27% of the guard
-  for a deterministic footprint — one model, no second cache to fund),
-  `--max-concurrent-requests 4` (ADR-012's **large-context** mark: ADR-010's
-  mark of 8 was measured at ~16K contexts, but the KV pool holds only ~83K
-  tokens of *total* concurrent context — ~0.433 GB/1K tokens against the
-  guard's 66 GB dynamic ceiling, ADR-011 — and eight 25–45K agentic streams
-  oversubscribe it ~3×: guard 400s, decode collapse, cache-evict spiral. At 4,
-  matching the pi subagent spawn cap, excess requests queue at admission and
-  consume no KV), `--api-key` from the 0600 file. The pi provider advertises
-  `contextWindow 76800` (the measured prefill-guard acceptance boundary,
-  ADR-011) and `maxTokens 8192` (ADR-012).
+  `--paged-ssd-cache-dir ~/.omlx/cache`, `--paged-ssd-cache-max-size 50GB`
+  (oMLX defaults the SSD tier to 100 GB; 50 GB keeps model + cache inside the
+  preflight's 130 GB free-disk budget), `--hot-cache-max-size 8GB` (the
+  gpt-oss weights leave no room for the GLM-era 24 GB tier under the ~73 GB
+  dynamic ceiling; 8 GB validated by the ADR-013 soak — prefix reuse 0.980),
+  `--max-concurrent-requests 1` (ADR-013's **serial** mark: the host serves
+  one request at a time by design, and the flag turns that client assumption
+  into a server-enforced invariant — a double-fired step or stray second
+  client queues at admission, consuming no KV; restoring parallel serving is a
+  model rollback, not a flag tweak), `--api-key` from the 0600 file. The pi
+  provider advertises `contextWindow 122880` (native 131,072 minus the 8,192
+  decode reservation — the model's position limit, not the guard, binds;
+  ADR-013) and `maxTokens 8192` (ADR-012, carried forward). Deep transcripts
+  should compact around ~60K tokens — past that the enforcer brushes soft
+  pressure and can transiently pause prefill (benign, self-recovering).
 - **Metal wired limit:** raise `iogpu.wired_limit_mb` to ~96 GB (98304); persist
   across reboot via a LaunchDaemon (sudo). The daemon stays loaded even when the
   server is stopped — it is a ceiling, not a reservation, and costs no memory idle.
@@ -218,11 +230,11 @@ best-current-model review.
   `protect-dev`/`protect-main` rulesets — renaming a job breaks its ruleset
   binding (ADR-007). The workflow files carry their own config comments.
 - `adrs/` — decision records (MADR minimal template in `TEMPLATE.md`; sequential,
-  zero-padded three digits). ADR-009 + ADR-010 are the current lineup decision,
-  with ADR-011 (pi contextWindow 76800) and ADR-012 (concurrency mark 4,
-  maxTokens 8192) the current serving-boundary amendments;
-  each file's `Status:` line carries the supersession chain (see "What this
-  repository is" above).
+  zero-padded three digits). ADR-009 (structure) + ADR-013 (serial
+  architecture, gpt-oss workhorse, mark 1, contextWindow 122880) are the
+  current lineup decision; ADR-010/011/012 are the amended GLM-era parameters
+  (the documented fallback configuration); each file's `Status:` line carries
+  the supersession chain (see "What this repository is" above).
 - `docs/router-wiring.md` — wiring the server into the .NET `IInferenceBackend` /
   `FallbackInferenceRouter`.
 - `docs/workhorse-probes.md` — one-time on-host probes to run before trusting the
@@ -280,9 +292,11 @@ After the server is up, validate against `http://localhost:8000/v1` (the script'
 1. `GET /v1/models` with the API key.
 2. A small `/v1/chat/completions` call.
 3. A **tool-calling** call confirming the model emits well-formed `tool_call`
-   markup — the orchestrator depends on this; flag if the parser needs config.
-4. A **2-way concurrency probe** (two parallel completions) — a general health
-   check that the batched LLM engine handles the fan-out this project serves.
+   markup (Harmony parsing on oMLX) — the orchestrator depends on this; flag
+   if the parser needs config.
+4. An **admission-queueing probe** (two parallel completions against the
+   serial mark of 1) — the second request must queue at admission and
+   complete, verifying the serial invariant degrades gracefully.
 5. A `POST /v1/messages` call confirming the Anthropic-style endpoint is reachable.
 6. An **effective cache-mode check**: the running instance's
    `PagedSSDCacheManager initialized:` log line must carry `hot_cache=` —
@@ -297,8 +311,10 @@ Anthropic-style clients use `/v1/messages`. The downstream consumer is an
 `IInferenceBackend` / `FallbackInferenceRouter`: fast/balanced roles →
 `coding-workhorse` (the single pinned local model); the quality role → the
 **cloud frontier** provider, never a local tier (see `docs/router-wiring.md`).
-Tool-bearing requests need `max_tokens ≥ ~200` — GLM emits a reasoning preamble
-before the tool call (validation uses 256).
+Tool-bearing requests need generous `max_tokens` — gpt-oss emits a Harmony
+reasoning channel before the tool call (validation uses 512). Under the serial
+mark, a prefill-guard 400 means "this one request is genuinely too big —
+compact and resubmit," not concurrency contention.
 
 ## Teardown
 
@@ -321,8 +337,9 @@ brew uninstall omlx && brew untap jundot/omlx
 # 4. Remove data (the API key + cache/logs, the workhorse, and any fallback/
 #    retired models still on disk)
 rm -rf ~/.omlx          # includes the 0600 api-key
-rm -rf ~/models/GLM-4.7-Flash-6bit
-rm -rf ~/models/GLM-4.7-Flash-8bit \
+rm -rf ~/models/gpt-oss-120b-4bit
+rm -rf ~/models/GLM-4.7-Flash-6bit \
+       ~/models/GLM-4.7-Flash-8bit \
        ~/models/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit \
        ~/models/Qwen3-Coder-Next-MLX-4bit   # fallbacks/retired tiers, if present
 ```

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # local-llm — oMLX provisioning for Apple Silicon
 
-Stand up a **local, OpenAI/Anthropic-compatible LLM inference server** on an Apple Silicon Mac using [oMLX](https://github.com/jundot/omlx), tuned for **parallel AI coding agents** — multiple concurrent requests sharing long system prefixes, where concurrent throughput and prefix-cache reuse matter more than single-stream tok/s.
+Stand up a **local, OpenAI/Anthropic-compatible LLM inference server** on an Apple Silicon Mac using [oMLX](https://github.com/jundot/omlx), tuned for a **serial AI coding workflow** — one request in flight at a time, each step extending a growing transcript, where single-stream decode, prefill speed, and turn-over-turn prefix-cache reuse matter ([ADR-013](adrs/013-gptoss-serial-workhorse.md) retired the earlier parallel fan-out premise).
 
 ## TL;DR — start now
 
-You need: an Apple Silicon Mac with **128 GB unified memory** (tuned for M5 Max; other Max-class chips warn but work), ~90 GB free disk (the workhorse model ≈ 24 GB, an SSD prefix-cache tier capped at 50 GB, plus staging slack), macOS, and [Homebrew](https://brew.sh). One step needs `sudo` (GPU wired-memory limit).
+You need: an Apple Silicon Mac with **128 GB unified memory** (tuned for M5 Max; other Max-class chips warn but work), ~130 GB free disk (the workhorse model ≈ 66 GB, an SSD prefix-cache tier capped at 50 GB, plus staging slack), macOS, and [Homebrew](https://brew.sh). One step needs `sudo` (GPU wired-memory limit).
 
 ```bash
 git clone https://github.com/psmfd/local-llm.git && cd local-llm
-./setup-omlx-m5.sh --download-model   # install + configure + fetch the workhorse (~24 GB)
+./setup-omlx-m5.sh --download-model   # install + configure + fetch the workhorse (~66 GB)
 omlxctl start                         # start the server on demand (NOT at login)
 ./setup-omlx-m5.sh --validate         # smoke-test the running server
 ```
@@ -23,14 +23,14 @@ The script is idempotent — re-running it skips whatever already exists. Run `.
 
 `setup-omlx-m5.sh` performs, in order:
 
-1. **Preflight** — hard-fails (exit `2`) on non-macOS, non-arm64, <~120 GB RAM, <~90 GB free disk, or missing Homebrew.
+1. **Preflight** — hard-fails (exit `2`) on non-macOS, non-arm64, <~120 GB RAM, <~130 GB free disk, or missing Homebrew.
 2. **Installs oMLX** via `brew tap jundot/omlx && brew install omlx` (no MCP — tool access stays explicit).
 3. **Creates directories** — `~/models`, `~/.omlx/{cache,logs,bin}` (`~/.omlx` is chmod 700).
 4. **Generates an API key** at `~/.omlx/api-key` (chmod 600, never printed).
 5. **Raises the Metal wired limit** to ~96 GB so the GPU can hold the model resident, persisted across reboots via a root LaunchDaemon (**the sudo step**).
 6. **Installs on-demand service control** — a start wrapper carrying the tuned serving flags, a per-user LaunchAgent (`RunAtLoad=false`, `KeepAlive=false` — registered at login but **not** started), and the `omlxctl` control tool (symlinked onto your `PATH` when the Homebrew bin is writable). Setup deliberately leaves the server stopped ([ADR-005](adrs/005-on-demand-service-lifecycle.md)).
 
-Model download is **opt-in** (`--download-model`); the base run never pulls weights. No engine override is applied — the workhorse is a verified text-only coder build, so oMLX runs it on its batched LLM engine and it is concurrency-safe as-is ([ADR-009](adrs/009-mac-single-workhorse-cloud-frontier.md)).
+Model download is **opt-in** (`--download-model`); the base run never pulls weights. No engine override is applied — the workhorse is a verified text-only build, so oMLX runs it on its batched LLM engine ([ADR-009](adrs/009-mac-single-workhorse-cloud-frontier.md) structure, [ADR-013](adrs/013-gptoss-serial-workhorse.md) model).
 
 ## The workhorse model
 
@@ -38,13 +38,13 @@ One pinned model ([ADR-009](adrs/009-mac-single-workhorse-cloud-frontier.md)) �
 
 | Alias | Model | ~Size | Residency |
 |---|---|---|---|
-| `coding-workhorse` | `mlx-community/GLM-4.7-Flash-6bit` (MoE, ~3 B active, 202 K ctx, MLA KV compression) | ~24 GB | pinned, sole resident |
+| `coding-workhorse` | `mlx-community/gpt-oss-120b-4bit` (MoE, 117 B total / 5.1 B active, 131 K ctx, sliding-window + GQA attention) | ~66 GB | pinned, sole resident |
 
-A single pinned model gives the parallel-agent fan-out **one shared prefix cache** and never exercises oMLX's multi-model swap path. The 6-bit quant was adopted after an on-host A/B measured quality parity with the 8-bit (tool-calls 58/58 each; HumanEval 81.7% vs 80.5%, statistical tie) while freeing ~7 GB of weights ([ADR-010](adrs/010-6bit-workhorse-sustained-mark.md)). `--max-concurrent-requests` is 4 — the **large-context** safe concurrency ([ADR-012](adrs/012-concurrency-mark-4-large-context.md)): ADR-010's mark of 8 was measured at ~16 K contexts, but the KV pool holds only ~83 K tokens of *total* concurrent context (~0.433 GB/1 K tokens against the guard's 66 GB dynamic ceiling — [ADR-011](adrs/011-pi-context-window-guard-boundary.md)), and eight admitted 25–45 K agentic streams oversubscribe it ~3× (2026-07-26 incident: guard 400s, decode collapse, cache-evict spiral). At 4 — matching the pi subagent spawn cap — excess requests queue at admission, consuming no KV. `GLM-4.7-Flash-8bit` stays on disk as the **primary inactive fallback** (rollback = pin swap + restart), with `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` as the secondary — neither is pinned or served by default. The setup script applies the alias + pin via the oMLX admin API (briefly starting the server, then stopping it; falls back to printed manual steps) and **unpins retired ADR-006 tiers** it finds. Re-verify the HuggingFace repo ID against current availability before downloading — the script probes it, but better checkpoints ship often.
+A single pinned model keeps one coherent prefix cache for the growing serial transcript and never exercises oMLX's multi-model swap path. gpt-oss-120b was adopted after on-host evidence beat the GLM-4.7-Flash incumbent on every measured axis — HumanEval 95.7% vs 83.5% (McNemar p=0.00018), +27% short-context decode, ~3× prefill, tool calls 58/58, and a 4-hour serial soak clean ([ADR-013](adrs/013-gptoss-serial-workhorse.md), [#73](https://github.com/psmfd/local-llm/issues/73)). `--max-concurrent-requests` is **1** — the serial mark: the host serves one request at a time by design, and the flag makes that a server-enforced invariant (a double-fired step queues at admission, consuming no KV). The pi provider advertises `contextWindow 122880` — the model's native 131,072 positions minus the 8,192 `maxTokens` reservation; unlike the GLM era ([ADR-011](adrs/011-pi-context-window-guard-boundary.md)) the model's position limit, not the memory guard, is the binding constraint. `GLM-4.7-Flash-6bit` stays on disk as the **primary inactive fallback** (rollback = pin swap + restore the GLM-era flags + restart — also the path back to parallel fan-out serving, which gpt-oss's weight footprint cannot host), with the 8-bit and `lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit` as deeper fallbacks — none pinned or served by default. The setup script applies the alias + pin via the oMLX admin API (briefly starting the server, then stopping it; falls back to printed manual steps) and **unpins retired tiers** it finds. Re-verify the HuggingFace repo ID against current availability before downloading — the script probes it, but better checkpoints ship often.
 
 ## Starting and stopping
 
-Startup is intentional — nothing wires the ~24 GB model until you ask. Control the server with `omlxctl` (installed to `~/.omlx/bin/omlxctl`, symlinked onto `PATH` when possible; otherwise call it by full path or add `~/.omlx/bin` to `PATH`):
+Startup is intentional — nothing wires the ~66 GB model until you ask. Control the server with `omlxctl` (installed to `~/.omlx/bin/omlxctl`, symlinked onto `PATH` when possible; otherwise call it by full path or add `~/.omlx/bin` to `PATH`):
 
 ```bash
 omlxctl start     # kickstart the server, then wait for /health (cold start ~90 s)
@@ -60,7 +60,7 @@ After a reboot or login, run `omlxctl start` to bring the server back.
 
 ## Validating
 
-`./setup-omlx-m5.sh --validate` runs six checks against the running server: model listing (including a warning if a retired ADR-006 tier is still pinned), a small chat completion, a **tool-calling** round-trip, a **2-way concurrency probe** (confirms the batched engine handles the fan-out), an Anthropic-style `/v1/messages` call, and an **effective cache-mode check** (the `hot_cache=` field in the server's cache-manager startup line — absent means the RAM tier is silently off, the incident class endpoint checks can't see). Before trusting the config under real load, also run the one-time on-host probes in [docs/workhorse-probes.md](docs/workhorse-probes.md) (long-context MLA check, `enable_thinking` pass-through).
+`./setup-omlx-m5.sh --validate` runs six checks against the running server: model listing (including a warning if a retired tier is still pinned), a small chat completion, a **tool-calling** round-trip (Harmony format), an **admission-queueing probe** (two parallel requests against the serial mark of 1 — the second must queue and complete), an Anthropic-style `/v1/messages` call, and an **effective cache-mode check** (the `hot_cache=` field in the server's cache-manager startup line — absent means the RAM tier is silently off, the incident class endpoint checks can't see). Before trusting the config under real load, also run the one-time on-host probes in [docs/workhorse-probes.md](docs/workhorse-probes.md).
 
 ## Connecting clients
 
@@ -76,7 +76,7 @@ After a reboot or login, run `omlxctl start` to bring the server back.
 | [`setup-omlx-m5.sh`](setup-omlx-m5.sh) | The provisioning script (idempotent; exit codes `0` pass / `1` error / `2` precondition) |
 | [`templates/`](templates/) | Start wrapper, LaunchAgent/LaunchDaemon plists, `omlxctl` control tool, Pi provider block — installed with placeholder substitution |
 | [`macos/local-llm-mac-os-creation.md`](macos/local-llm-mac-os-creation.md) | The authoritative implementation brief |
-| [`adrs/`](adrs/) | Decision records — the current config is [ADR-010](adrs/010-6bit-workhorse-sustained-mark.md) (6-bit quant + sustained mark of 8) plus [ADR-011](adrs/011-pi-context-window-guard-boundary.md) (pi-advertised contextWindow 76800, the measured prefill-guard boundary) and [ADR-012](adrs/012-concurrency-mark-4-large-context.md) (concurrency mark 4 + maxTokens 8192 for the large-context era), all amending [ADR-009](adrs/009-mac-single-workhorse-cloud-frontier.md) (single-model workhorse, cloud as frontier; supersedes [ADR-006](adrs/006-multi-tier-coresident-lineup-stay-on-omlx.md) three-tier lineup and [ADR-008](adrs/008-cross-host-routing-integration.md) cross-host AMD routing), plus [ADR-005](adrs/005-on-demand-service-lifecycle.md) (on-demand lifecycle, no login autostart — still in force) |
+| [`adrs/`](adrs/) | Decision records — the current config is [ADR-013](adrs/013-gptoss-serial-workhorse.md) (serial workflow architecture + gpt-oss-120b workhorse, mark 1, contextWindow 122880) amending [ADR-009](adrs/009-mac-single-workhorse-cloud-frontier.md) (single-model workhorse, cloud as frontier); the GLM-era parameters — [ADR-010](adrs/010-6bit-workhorse-sustained-mark.md) (6-bit quant), [ADR-011](adrs/011-pi-context-window-guard-boundary.md) (guard-bound contextWindow), [ADR-012](adrs/012-concurrency-mark-4-large-context.md) (mark 4 + maxTokens 8192, of which maxTokens carries forward) — describe the documented fallback configuration; plus [ADR-005](adrs/005-on-demand-service-lifecycle.md) (on-demand lifecycle, no login autostart — still in force) |
 | `.claude/agents/`, `.github/agents/` | Repository-resident `omlx-expert` domain agent (read-only/advisory) for Claude Code and GitHub Copilot |
 | [`.github/workflows/`](.github/workflows/) | CI lint gate — `validate` (shellcheck + markdownlint + plist well-formedness) and `lint-pr-title` (Conventional Commits), required checks on the branch rulesets ([ADR-007](adrs/007-ci-rulesets-and-release-strategy.md)); plus `upstream-watch` (weekly upstream oMLX release/issue watch that files tracking issues — not a required check) |
 | [`docs/router-wiring.md`](docs/router-wiring.md) | Wiring the server into a .NET `IInferenceBackend` / `FallbackInferenceRouter` |
@@ -91,11 +91,11 @@ If you previously provisioned the three-tier lineup, just re-run the script — 
 
 ```bash
 git pull
-./setup-omlx-m5.sh            # GLM is already on disk from T2 — no download needed
-./setup-omlx-m5.sh --validate # confirms coding-workhorse resolves and retired tiers are unpinned
+./setup-omlx-m5.sh --download-model   # fetches gpt-oss-120b-4bit (~66 GB) if absent
+./setup-omlx-m5.sh --validate         # confirms coding-workhorse resolves and retired tiers are unpinned
 ```
 
-The re-run re-renders the start wrapper with the current serving flags (`--hot-cache-max-size 24GB`, `--max-concurrent-requests 4`, `--paged-ssd-cache-max-size 50GB`), downloads the 6-bit workhorse if absent (`--download-model`), and **actively unpins the retired models** via the admin API so their memory is actually freed — first renaming `GLM-4.7-Flash-8bit` to alias `workhorse-8b` so `coding-workhorse` transfers cleanly to the 6-bit, and clearing any still-pinned ADR-006 tiers (Qwen3-Coder-30B, Qwen3-Coder-Next). Retired models stay on disk (the 8-bit is the primary inactive fallback, Qwen3-Coder-30B the secondary; delete Qwen3-Coder-Next by hand if you want the disk back). If the server is running when you re-run, the wrapper update stops it (restart with `omlxctl start`). It never overwrites your API key, the oMLX-managed `model_settings.json` (it merges via the admin API), or a non-empty Pi config (a merge snippet is left at `~/.omlx/pi-provider-snippet.json` — note the provider now exposes only `coding-workhorse`). Running it twice is a no-op.
+The re-run re-renders the start wrapper with the current serving flags (`--hot-cache-max-size 8GB`, `--max-concurrent-requests 1`, `--paged-ssd-cache-max-size 50GB`), downloads the gpt-oss workhorse if absent (`--download-model`), and **actively unpins the retired models** via the admin API so their memory is actually freed — first renaming `GLM-4.7-Flash-6bit` to alias `workhorse-glm` (and the 8-bit to `workhorse-8b`) so `coding-workhorse` transfers cleanly to gpt-oss, and clearing any still-pinned ADR-006 tiers (Qwen3-Coder-30B, Qwen3-Coder-Next). Retired models stay on disk (the GLM-6bit is the primary inactive fallback — also the rollback path to parallel fan-out serving; delete the others by hand if you want the disk back). If the server is running when you re-run, the wrapper update stops it (restart with `omlxctl start`). It never overwrites your API key, the oMLX-managed `model_settings.json` (it merges via the admin API), or a non-empty Pi config (a merge snippet is left at `~/.omlx/pi-provider-snippet.json` — note the provider now exposes only `coding-workhorse`). Running it twice is a no-op.
 
 ## Teardown
 
@@ -110,9 +110,10 @@ sudo launchctl bootout system/com.local.iogpu-wired-limit 2>/dev/null || true
 sudo rm -f /Library/LaunchDaemons/com.local.iogpu-wired-limit.plist
 brew uninstall omlx && brew untap jundot/omlx
 rm -rf ~/.omlx \
-  ~/models/GLM-4.7-Flash-6bit                       # the workhorse
+  ~/models/gpt-oss-120b-4bit                        # the workhorse
 # Also remove whichever fallback/retired models are still on disk:
-rm -rf ~/models/GLM-4.7-Flash-8bit \
+rm -rf ~/models/GLM-4.7-Flash-6bit \
+  ~/models/GLM-4.7-Flash-8bit \
   ~/models/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit \
   ~/models/Qwen3-Coder-Next-MLX-4bit
 ```

--- a/adrs/009-mac-single-workhorse-cloud-frontier.md
+++ b/adrs/009-mac-single-workhorse-cloud-frontier.md
@@ -1,7 +1,9 @@
 # ADR-009: Mac as a single-model subagent workhorse, with the cloud as the frontier
 
 - Status: accepted (workhorse quantization and concurrency mark amended by
-  [ADR-010](010-6bit-workhorse-sustained-mark.md))
+  [ADR-010](010-6bit-workhorse-sustained-mark.md); workhorse model and the
+  parallel fan-out serving premise amended by
+  [ADR-013](013-gptoss-serial-workhorse.md))
 - Date: 2026-06-29 (implemented 2026-07-02, [#14](https://github.com/psmfd/local-llm/issues/14))
 
 Supersedes [ADR-006](006-multi-tier-coresident-lineup-stay-on-omlx.md) (three-tier

--- a/adrs/010-6bit-workhorse-sustained-mark.md
+++ b/adrs/010-6bit-workhorse-sustained-mark.md
@@ -1,6 +1,8 @@
 # ADR-010: 6-bit workhorse quant and a sustained concurrency mark of 8
 
-- Status: accepted
+- Status: accepted (amended by [ADR-013](013-gptoss-serial-workhorse.md) — the
+  GLM-specific quant choice and sustained mark go dormant with the workhorse
+  swap; the 6-bit remains the primary-fallback configuration)
 - Date: 2026-07-04 ([#22](https://github.com/psmfd/local-llm/issues/22),
   [#23](https://github.com/psmfd/local-llm/issues/23))
 

--- a/adrs/011-pi-context-window-guard-boundary.md
+++ b/adrs/011-pi-context-window-guard-boundary.md
@@ -1,6 +1,9 @@
 # ADR-011: pi-advertised contextWindow lowered to the prefill-guard boundary
 
-- Status: accepted
+- Status: accepted (contextWindow superseded by
+  [ADR-013](013-gptoss-serial-workhorse.md): 76800 → 122880 — the binding
+  constraint moved from the prefill guard to the new workhorse's native
+  position limit)
 - Date: 2026-07-26 ([#50](https://github.com/psmfd/local-llm/issues/50);
   benchmark in [pi_config#889](https://github.com/psmfd/pi_config/issues/889#issuecomment-5083521123))
 

--- a/adrs/012-concurrency-mark-4-large-context.md
+++ b/adrs/012-concurrency-mark-4-large-context.md
@@ -1,6 +1,8 @@
 # ADR-012: concurrency mark 4 and maxTokens 8192 for the large-context era
 
-- Status: accepted
+- Status: accepted (concurrency mark superseded by
+  [ADR-013](013-gptoss-serial-workhorse.md): 4 → 1 under the serial workflow
+  architecture; the maxTokens 8192 decision stands)
 - Date: 2026-07-26 ([#52](https://github.com/psmfd/local-llm/issues/52);
   incident analysis in [pi_config#889](https://github.com/psmfd/pi_config/issues/889))
 

--- a/adrs/013-gptoss-serial-workhorse.md
+++ b/adrs/013-gptoss-serial-workhorse.md
@@ -1,0 +1,116 @@
+# ADR-013: serial workflow architecture and the gpt-oss-120b workhorse
+
+- Status: accepted
+- Date: 2026-08-24 ([#71](https://github.com/psmfd/local-llm/issues/71),
+  [#73](https://github.com/psmfd/local-llm/issues/73))
+
+Amends [ADR-009](009-mac-single-workhorse-cloud-frontier.md): the
+single-pinned-workhorse + cloud-frontier structure stands unchanged; this ADR
+replaces the workhorse model (`GLM-4.7-Flash-6bit` →
+`mlx-community/gpt-oss-120b-4bit`) and retires the parallel fan-out serving
+premise the ADR-009 lineup was tuned for. Amends
+[ADR-010](010-6bit-workhorse-sustained-mark.md) (the 6-bit-vs-8-bit quant
+decision and sustained mark are GLM-specific and go dormant with the model),
+[ADR-011](011-pi-context-window-guard-boundary.md) (pi `contextWindow`
+76800 → 122880 — the binding constraint moves from the prefill guard to the
+model's native position limit), and
+[ADR-012](012-concurrency-mark-4-large-context.md)
+(`--max-concurrent-requests` 4 → 1; the pi `maxTokens` 8192 stands).
+
+## Context and Problem Statement
+
+The host's client workload is moving from a parallel agent fan-out (3+
+concurrent requests sharing long system prefixes — the premise of ADR-009
+through ADR-012) to a strictly serial workflow: one request in flight, each
+step's output feeding the next as a growing transcript. Under that shape,
+should the workhorse remain GLM-4.7-Flash-6bit, or is a better model available
+once the concurrency-driven constraints no longer bind?
+
+A three-angle research pass (2026-08-21) found exactly one candidate the
+ADR-009-era survey never screened: `gpt-oss-120b-4bit` (117B total / 5.1B
+active MoE, alternating sliding-window(128)/full attention with 8-head GQA,
+text-only `GptOssForCausalLM`, native 131,072 context, Harmony tool format).
+Everything else new since the ADR-009 survey is disqualified by size
+(GLM-5.x, MiniMax M2.5/M2.7, Kimi K2.x), hybrid-SSM architecture that breaks
+prefix-cache reuse — fatal for a growing-transcript workload (the whole
+Qwen3.5+ generation incl. Qwen3-Coder-Next; mlx-lm #980, oMLX #825) — or
+multimodality (Gemma 4, Muse-Glimmer). No Flash/Air-class GLM successor
+exists. Speculative decoding (DFlash) was separately evaluated and closed
+no-go for GLM ([#71](https://github.com/psmfd/local-llm/issues/71) — no
+trained draft checkpoint for `Glm4MoeLiteForCausalLM`).
+
+## Considered Options
+
+- Keep GLM-4.7-Flash-6bit, retune flags for serial (mark 1; no model change)
+- Switch the workhorse to `mlx-community/gpt-oss-120b-4bit`
+- Unlock a vision-tagged candidate (Gemma-4-31B / Muse-Glimmer-30B) via
+  `model_type_override: llm` under serial-only load
+- A hybrid-SSM large-MoE (Qwen3-Coder-Next-80B) for its size/fit
+
+## Decision Outcome
+
+Chosen option: "switch to `gpt-oss-120b-4bit`", because on-host evidence
+([#73](https://github.com/psmfd/local-llm/issues/73), 2026-08-21 → 2026-08-24,
+oMLX 0.5.7) shows it beats the incumbent on every measured axis while fitting
+the host — and the fit is only possible because the fan-out requirement is
+gone (61.56 GB of weights leave no multi-stream KV pool):
+
+| Axis | gpt-oss-120b-4bit | GLM-4.7-Flash-6bit |
+| --- | --- | --- |
+| HumanEval pass@1 (greedy, 164, tests executed) | **95.7%** (157/164) | 83.5% as deployed; 85.4% thinking-on |
+| Paired McNemar | **24 vs 4 discordant, p = 0.00018** | — |
+| Decode, short context | **~106 tok/s** | 83.1 tok/s |
+| Decode at ~60K / ~77K / ~130K ctx | **55 / 50 / 36 tok/s** | ~44–47 tok/s at ~44K; n/a past ~98K |
+| Cold prefill at 76.8K | **~67 s (1,162 tok/s)** | ~3.3 min (~400 tok/s) |
+| Context boundary | **native 131,072 (guard never rejects first)** | ~91–98K guard boundary |
+| Tool battery (ADR-010 58-call scale) | **58/58**, incl. 13K-deep needles + multi-tool round-trips | 58/58 (ADR-010) |
+| KV cost | **~0.070 GB/1K** (sliding-window + GQA) | ~0.36 GB/1K (MLA) |
+| 4.09 h serial soak (target flags) | **962 steps, 0 errors, reuse 0.980, RSS flat** | n/a (not run) |
+
+The rejected options: keeping GLM forfeits a statistically decisive quality
+gap (+12.2 pts, p = 0.00018) plus every performance axis; the vision-tagged
+candidates carry their own non-concurrency correctness bugs (oMLX #1670) or
+have zero benchmark/tool evidence; hybrid-SSM models break the prefix-cache
+reuse a growing transcript lives on (soak measured 98% reuse — the property
+the architecture must keep).
+
+### Serving parameters (replacing the ADR-010/011/012 values)
+
+| Parameter | Old (ADR-009..012) | New | Why |
+| --- | --- | --- | --- |
+| Pinned model / alias `coding-workhorse` | `GLM-4.7-Flash-6bit` | `gpt-oss-120b-4bit` | this ADR |
+| `--max-concurrent-requests` | 4 | **1** | serial invariant; converts a client assumption into a server guarantee — a double-fired step queues instead of competing for KV |
+| `--hot-cache-max-size` | 24GB | **8GB** | 61.56 GB weights + 24 GB cache exceeds the ~73 GB dynamic ceiling; 8 GB validated by the soak (reuse 0.980) |
+| pi `contextWindow` | 76800 | **122880** | native 131,072 minus the 8,192 maxTokens reservation; guard accepts ≥130K fresh and post-soak (#73 ladder) |
+| pi `maxTokens` | 8192 | 8192 | stands (pi output-shrink ladder caps at 8,000) |
+| Guard / wired limit / SSD cache | 90 GB / 96 GB / 50GB | unchanged | bandwidth- and disk-bound, not model-bound |
+| Reasoning control | `chat_template_kwargs: {"enable_thinking": false}` (GLM-ism) | `chat_template_kwargs: {"reasoning_effort": "medium"}`; `low` = latency knob | top-level `reasoning_effort` param is ignored by oMLX 0.5.7; medium is the 95.7%-HumanEval setting; delivery via pi payload-tuner ([pi_config#1052](https://github.com/psmfd/pi_config/issues/1052)) |
+
+### Consequences
+
+- Good, because quality, decode, prefill, and context window all improve
+  simultaneously — there is no measured axis on which the incumbent wins.
+- Good, because the serial shape structurally eliminates the ADR-010/012
+  incident class (concurrent-admission cache-evict spiral) and the open #45
+  head-of-line fairness bug.
+- Bad, because the host loses real fan-out capacity: at mark 1 a second
+  concurrent client queues. Restoring parallel serving means reverting to a
+  small-footprint model — this ADR makes serial-vs-parallel a *model* decision,
+  not a flag decision.
+- Bad, because idle margin is thin (~11.7 GB: 73.26 GB ceiling − 61.56 GB
+  weights). The 4-hour soak on the target flags showed no creep (RSS flat,
+  pressure peaks stable at ~77.9 GB) and a post-soak fresh-100K prompt still
+  accepted, but deep sessions (~60–70K) brush the soft-pressure threshold: 8
+  transient self-recovering `adaptive_prefill_throttle` pauses in 4 h, zero
+  failed requests. Workflows SHOULD cycle/compact transcripts around ~60K
+  tokens; the pause is otherwise benign backpressure.
+- Bad, because Harmony-format parsing is a newer oMLX integration surface than
+  GLM's (fixed-bug history through 0.4.x–0.5.x). Mitigated by the 58/58
+  battery on 0.5.7; re-run the battery on every oMLX upgrade.
+- Rollback is cheap by design: GLM-4.7-Flash-6bit stays on disk as the primary
+  inactive fallback (the ADR-010 pinned-swap pattern — repoint the pin via the
+  admin API, restore the previous wrapper flags, restart); the 8-bit and
+  Qwen3-Coder-30B remain the deeper fallbacks.
+- The `--validate` concurrency probe changes meaning: at mark 1 the two-way
+  probe verifies queue-then-complete (admission queueing) rather than parallel
+  completion.

--- a/docs/router-wiring.md
+++ b/docs/router-wiring.md
@@ -245,14 +245,18 @@ builder.Services.AddTransient<FallbackInferenceRouter>();
 - **Role routing.** `Fast` / `Balanced` → **Mac oMLX workhorse** primary → cloud
   fallback. `Quality` → oMLX throws `InferenceUnavailableException` (no local
   quality tier — the alias dictionary omits the role) → **cloud frontier**.
-- **Saturation.** oMLX runs at `--max-concurrent-requests 4` (**the
-  large-context mark**,
-  [ADR-012](../adrs/012-concurrency-mark-4-large-context.md):
-  [ADR-010](../adrs/010-6bit-workhorse-sustained-mark.md)'s mark of 8 was
-  measured at ~16K contexts, but real 25–45K agentic streams oversubscribe the
-  ~83K-token shared KV pool ~3× — 2026-07-26 incident; at 4, matching the pi
-  subagent spawn cap, excess requests queue at admission and consume no KV).
-  **Saturation surfaces as HTTP `400`, not 429/503.** On oMLX 0.5.7 an
+- **Saturation.** oMLX runs at `--max-concurrent-requests 1` (**the serial
+  mark**, [ADR-013](../adrs/013-gptoss-serial-workhorse.md), superseding
+  [ADR-012](../adrs/012-concurrency-mark-4-large-context.md)'s 4): the host
+  serves one request at a time by design; a concurrent second request queues
+  at admission and consumes no KV, so router-side concurrency limiting is
+  unnecessary — but keep router calls serial anyway to avoid queue-inflated
+  latencies. **Under the serial mark a prefill-guard rejection is never
+  contention** — it means this one request's prompt is genuinely over the
+  boundary, so the correct reaction is **compact/trim and resubmit** (or
+  divert that request to the cloud), not backoff-and-retry of the same
+  payload, which will fail identically.
+  **The rejection surfaces as HTTP `400`, not 429/503.** On oMLX 0.5.7 an
   over-boundary prompt is rejected **pre-compute**: a new preflight path
   returns the 400 instantly (`wall=0 s`), and the body carries a new
   machine-readable `code: "prefill_memory_exceeded"` alongside the existing
@@ -265,19 +269,25 @@ builder.Services.AddTransient<FallbackInferenceRouter>();
   secondary tell; the 0.5.7 re-baseline did not observe this shape for the
   single-stream case (the preflight 400 superseded it there), but it left
   open whether a post-admission mid-flight reject can still surface this way
-  under concurrent load. The router MUST treat any of these signals as a
-  **capacity signal** — retry with backoff or trip the circuit breaker and
-  divert to the cloud frontier — never as a permanent client error (a generic
-  400 without either marker remains a real client error). A 429 or a
-  memory-guard 500 still trips the breaker as before. **Parse response bodies
+  under concurrent load. The router MUST treat any of these signals as an
+  **over-boundary signal for that request** — compact/trim the prompt and
+  resubmit, or divert that request to the cloud frontier — never as a
+  permanent client error (a generic 400 without either marker remains a real
+  client error) and, under the serial mark, never as transient contention to
+  retry unchanged. A 429 or a memory-guard 500 still trips the breaker as
+  before. **Parse response bodies
   leniently:** successful large responses can arrive with ~30 bytes of
   leading whitespace before the JSON body (an artifact of oMLX's
   `_with_json_keepalive`, jundot/omlx#2066) — use a whitespace-tolerant JSON
   parser, not one that rejects leading bytes.
-- **max_tokens.** GLM-4.7-Flash emits a **reasoning preamble before tool calls**;
-  set `InferenceRequest.MaxTokens` ≥ ~200 on tool-bearing requests so the call is
-  not truncated, and keep `AttemptTimeout` generous (no cold-load tier anymore,
-  but decode + preamble still take time).
+- **max_tokens.** gpt-oss emits a **Harmony reasoning channel before answers
+  and tool calls** (default effort medium); set `InferenceRequest.MaxTokens`
+  generously on tool-bearing requests (validation uses 512) so the call is not
+  truncated mid-reasoning, and keep `AttemptTimeout` generous (no cold-load
+  tier anymore, but reasoning + decode still take time). Reasoning effort is
+  tunable per request via `chat_template_kwargs: {"reasoning_effort":
+  "low|medium|high"}` — the top-level `reasoning_effort` param is ignored by
+  oMLX 0.5.7 (ADR-013).
 
 > **Historical note.** Earlier revisions of this doc described the ADR-006
 > three-tier wiring (`coding-fast`/`coding-balanced`/`coding-quality` all local)

--- a/docs/workhorse-probes.md
+++ b/docs/workhorse-probes.md
@@ -66,6 +66,15 @@ deliberately avoid.
 > one-time SSD-cache partial invalidation at first start (831/3,872 blocks
 > skipped) was expected. See the probe-2 "0.5.7 smoke" note and the probe-3
 > "0.5.7 re-baseline" subsection.
+>
+> **Probe 5 first run: 2026-08-21, oMLX 0.5.7 (MLX 0.32.0), macOS 26.5.2 —
+> single-stream decode baseline 83.1 tok/s median** at short context
+> (three runs, 83.0–83.4 — see probe 5). Live-log anchors at long context:
+> ~44–47 tok/s at ~44K-token prompts; 36.6 tok/s across a 16K-token
+> generation. Captured during the serial-workload assessment as the
+> denominator for any future speculative-decoding A/B (#71 — DFlash revisit,
+> closed no-go: no trained DFlash draft checkpoint or dflash-mlx target
+> adapter exists for `Glm4MoeLiteForCausalLM`).
 
 Prereqs: server provisioned, `omlxctl start` done, `KEY="$(cat ~/.omlx/api-key)"`.
 
@@ -432,6 +441,74 @@ jundot/omlx#1835).
 56.7 TFLOPS fp16 / 57.3 TFLOPS bf16 vs the 0.5.3 baseline 57.4/57.3 — within
 noise; Neural Accelerators engaged — PASS
 (`.session-notes/057-rebaseline/results.md`).
+
+## 5. Single-stream decode baseline (serial-workload reference)
+
+**Why.** Every decode figure the earlier probes recorded was measured under
+concurrent load and is contaminated by contention (probe 3's 0.9–7.9 tok/s
+figures are the #45 head-of-line-fairness artifact, not a hardware ceiling).
+The repo had no clean single-stream number at all — yet that number is the
+denominator for any speculative-decoding A/B (see #71) and the operative
+throughput figure if the client workload ever runs serially. This probe
+records it.
+
+**Procedure.** One isolated streaming completion at a time, no concurrent
+traffic (check `omlxctl logs` for a quiet window first). Small cold prompt so
+prefill is negligible; decode tok/s excludes TTFT by timing first-to-last
+streamed token:
+
+```bash
+python3 - <<'EOF'
+import json, statistics, time, urllib.request
+from pathlib import Path
+KEY = Path.home().joinpath(".omlx/api-key").read_text().strip()
+PROMPT = ("Write a detailed technical explanation of how CPU cache "
+          "hierarchies work. Be thorough and keep going until cut off.")
+results = []
+for i in range(3):
+    body = json.dumps({"model": "coding-workhorse",
+                       "messages": [{"role": "user", "content": PROMPT}],
+                       "max_tokens": 1024, "stream": True,
+                       "stream_options": {"include_usage": True}}).encode()
+    req = urllib.request.Request(
+        "http://localhost:8000/v1/chat/completions", data=body,
+        headers={"Content-Type": "application/json",
+                 "Authorization": f"Bearer {KEY}"})
+    t0 = time.monotonic(); t_first = t_last = None; usage = None
+    with urllib.request.urlopen(req, timeout=300) as resp:
+        for raw in resp:
+            line = raw.decode("utf-8", "replace").strip()
+            if not line.startswith("data: ") or line == "data: [DONE]":
+                continue
+            evt = json.loads(line[6:])
+            if evt.get("usage"):
+                usage = evt["usage"]
+            ch = evt.get("choices") or []
+            d = ch[0].get("delta") if ch else None
+            if d and (d.get("content") or d.get("reasoning_content")):
+                t_last = time.monotonic()
+                t_first = t_first or t_last
+    n = usage["completion_tokens"]
+    toks = round((n - 1) / (t_last - t_first), 2)
+    print(f"run {i+1}: ttft={t_first-t0:.3f}s tokens={n} decode={toks} tok/s")
+    results.append(toks); time.sleep(2)
+print("median:", statistics.median(results), "tok/s")
+EOF
+```
+
+**Pass:** n/a — a reference measurement, not a gate. Record the median and
+compare against the prior entry after any oMLX, MLX, macOS, or quant change;
+an unexplained regression is grounds to bisect before trusting the upgrade.
+
+**Last run (2026-08-21, oMLX 0.5.7 brew keg, MLX 0.32.0, macOS 26.5.2):**
+**83.1 tok/s median** (83.39 / 82.96 / 83.10 — spread under 0.5%), TTFT
+0.33–0.45 s, 48-token cold prompt (`cached=0` all runs), 1024-token
+generations. Context-length sensitivity from the same day's live logs
+(serial requests, warm cache): ~44–47 tok/s at ~44–45K-token prompts and
+36.6 tok/s across a full 16K-token generation at ~45.8K prompt — attention/
+KV-read cost roughly halves decode speed by ~45K context. Captured for the
+serial-workload assessment and the #71 DFlash revisit (closed no-go —
+architecture unsupported; the baseline outlives the ticket).
 
 Note the outcome (date, oMLX version, pass/fail, measured numbers) in the PR or
 issue that prompted the re-run. If probe 1 fails, that is grounds to revisit

--- a/docs/workhorse-probes.md
+++ b/docs/workhorse-probes.md
@@ -6,6 +6,21 @@ review flagged. None is part of `--validate` — each needs a long prompt, a
 model-behavior judgement, or a host-level measurement that the scripted checks
 deliberately avoid.
 
+> **ADR-013 model swap (2026-08-24):** the workhorse is now
+> `gpt-oss-120b-4bit`; probes 1 (MLA-specific) and 2 (`enable_thinking`, a
+> GLM-ism) describe the **GLM fallback configuration** — run them only when
+> rolling back to `workhorse-glm`. The gpt-oss equivalents were measured in
+> [#73](https://github.com/psmfd/local-llm/issues/73): KV slope ~0.070 GB/1K
+> (sliding-window + GQA; oMLX block estimator 4.50 MB/64 tok), prefill ladder
+> 100K/120K/130K-token prompts all ACCEPTED (1,148/1,067/994 tok/s; decode
+> 47.2/41.0/36.1 after), Harmony tool battery 58/58 incl. 13K-deep needles,
+> reasoning control via `chat_template_kwargs: {"reasoning_effort": ...}`
+> (the top-level param is ignored — the probe-2 analog), single-stream decode
+> ~106 tok/s short-context (probe-5 analog), and a 4.09 h serial soak on the
+> ADR-013 flags (962 steps, reuse 0.980, RSS flat, 8 transient
+> `adaptive_prefill_throttle` pauses at ~60–70K depth — compact around ~60K).
+> Re-run the #73 gauntlet after any oMLX, macOS, or model change.
+>
 > **Last run: 2026-07-02, oMLX 0.4.4 — both probes PASS.** Probe 1: baseline
 > 30.0 GB resident; a 19,470-token prompt added +2.1 GB resident / +7.0 GB peak
 > (MLA-class — an MHA fallback would have added ~18 GB), with 19,456/19,470

--- a/setup-omlx-m5.sh
+++ b/setup-omlx-m5.sh
@@ -12,7 +12,7 @@
 #   ./setup-omlx-m5.sh [options]
 #
 # Options:
-#   --download-model   Download the coding-workhorse model (~24 GB) via
+#   --download-model   Download the coding-workhorse model (~66 GB) via
 #                      `hf download`. Off by default. Retired ADR-006 tiers are
 #                      never downloaded. Existing model dirs are skipped (never
 #                      re-downloaded or deleted), so this is safe to re-run when
@@ -81,50 +81,53 @@ WIRED_LIMIT_MB=98304    # 96 GB; leaves ~32 GB for macOS on a 128 GB host (ADR-0
 WIRED_MIN_MB=90000      # wrapper warns below this
 
 MIN_RAM_GB=120
-MIN_DISK_GB=90          # GLM-4.7-Flash-6bit (~24 GB) + SSD prefix-cache tier
-                        # capped at 50 GB + hf staging/logs headroom (ADR-010).
+MIN_DISK_GB=130         # gpt-oss-120b-4bit (~66 GB) + SSD prefix-cache tier
+                        # capped at 50 GB + hf staging/logs headroom (ADR-013).
                         # Gates required FREE space only — retired tiers and the
-                        # 8-bit fallback already on disk are sunk cost, not part
+                        # GLM fallbacks already on disk are sunk cost, not part
                         # of this floor.
 
-# --- Model lineup (ADR-009 lineup, ADR-010 quant: single Mac workhorse) ------
-# ADR-006's three co-resident/on-demand tiers are retired: the cloud provider is
-# now the quality frontier and the Mac's only job is to serve a homogeneous
-# subagent fan-out from ONE pinned model, maximizing shared prefix-cache reuse
-# and KV headroom under the 90 GB guard. The model is a verified TEXT-ONLY MLX
-# coder build (no vision_config → batched LLM engine, no engine override) and
-# tool-call-verified on oMLX. ADR-010 moved the quant 8-bit → 6-bit after an
-# on-host A/B measured quality parity (tool-calls 58/58 each; HumanEval 81.7%
-# vs 80.5%, statistical tie) and a doubled sustained-load margin. Repo ID
-# verified against HuggingFace config.json 2026-07-04 (ADR-010); re-probed
-# before download. See adrs/010-6bit-workhorse-sustained-mark.md (decision),
-# adrs/009-mac-single-workhorse-cloud-frontier.md (lineup), and
-# docs/workhorse-probes.md (probe 3 — the sustained-load measurements).
+# --- Model lineup (ADR-009 structure, ADR-013 model: single Mac workhorse) ---
+# ADR-009's single-pinned-workhorse + cloud-frontier structure stands; ADR-013
+# swapped the model and the serving shape: the Mac now serves a STRICTLY SERIAL
+# workflow (one request in flight, growing transcript) rather than a parallel
+# fan-out, and the workhorse is gpt-oss-120b-4bit (117B total / 5.1B active
+# MoE, alternating sliding-window/full attention, ~0.070 GB/1K KV — a single
+# stream reaches the model's full native 131,072 context inside the guard).
+# A verified TEXT-ONLY MLX build (no vision_config → batched LLM engine, no
+# engine override), Harmony tool calling verified 58/58 on oMLX 0.5.7, and
+# HumanEval 95.7% vs the GLM incumbent's 83.5% (McNemar p=0.00018). Repo ID
+# verified against HuggingFace config.json 2026-08-21 (#73); re-probed before
+# download. See adrs/013-gptoss-serial-workhorse.md (decision + evidence),
+# adrs/009-mac-single-workhorse-cloud-frontier.md (structure), and
+# docs/workhorse-probes.md (probe measurements).
 #
 # TIER_MODELS holds exactly one entry, "repo|alias|pinned(true|false)", so every
 # existing loop (download, pi-config, pin/alias, validate) works unchanged over a
 # 1-element, Bash-3.2-safe indexed array (macOS default shell).
 TIER_MODELS=(
-    "mlx-community/GLM-4.7-Flash-6bit|coding-workhorse|true"
+    "mlx-community/gpt-oss-120b-4bit|coding-workhorse|true"
 )
 # The workhorse's alias drives the detailed validation probes below
 # (chat/tool/concurrency).
 PRIMARY_ALIAS="coding-workhorse"
 
 # RETIRED_MODELS: models this script no longer downloads, aliases, or validates
-# — the ADR-006 tiers plus the ADR-010-retired 8-bit workhorse. Entries stay on
-# disk (never deleted); the 8-bit is the PRIMARY inactive fallback (same model,
-# quality-parity-tested rollback) and Qwen3-Coder-30B the secondary
-# (different-family) fallback. apply_pins clears is_pinned/dflash on these —
-# only when they already exist in oMLX's model_settings.json — so an upgraded
-# host actually frees the memory. Format: "repo|alias_to_set" (2 fields — no pin
-# field; the action is always force-unpin). The alias field is what the unpin
-# PUT SETS: for the ADR-006 tiers it echoes their old alias unchanged (the admin
-# PUT's replace-vs-merge semantics for omitted fields are unverified; a stale
-# alias on an unpinned model is inert), but for the 8-bit it RENAMES the model
-# off 'coding-workhorse' so the primary alias transfers cleanly to the 6-bit —
+# — the ADR-006 tiers plus the retired GLM workhorses (ADR-010's 8-bit, and
+# ADR-013's 6-bit). Entries stay on disk (never deleted); the GLM-4.7-Flash-
+# 6bit is the PRIMARY inactive fallback (full ADR-009/010 probe history,
+# pinned-swap rollback per ADR-013), the 8-bit and Qwen3-Coder-30B the deeper
+# fallbacks. apply_pins clears is_pinned/dflash on these — only when they
+# already exist in oMLX's model_settings.json — so an upgraded host actually
+# frees the memory. Format: "repo|alias_to_set" (2 fields — no pin field; the
+# action is always force-unpin). The alias field is what the unpin PUT SETS:
+# for the ADR-006 tiers it echoes their old alias unchanged (the admin PUT's
+# replace-vs-merge semantics for omitted fields are unverified; a stale alias
+# on an unpinned model is inert), but for the GLM-6bit it RENAMES the model
+# off 'coding-workhorse' so the primary alias transfers cleanly to gpt-oss —
 # which is why the unpin pass runs BEFORE the workhorse pin in apply_pins.
 RETIRED_MODELS=(
+    "mlx-community/GLM-4.7-Flash-6bit|workhorse-glm"
     "mlx-community/GLM-4.7-Flash-8bit|workhorse-8b"
     "lmstudio-community/Qwen3-Coder-30B-A3B-Instruct-MLX-8bit|coding-fast"
     "lmstudio-community/Qwen3-Coder-Next-MLX-4bit|coding-quality"
@@ -139,17 +142,19 @@ tier_pin()   { printf '%s' "${1##*|}"; }
 tier_dir()   { printf '%s' "$MODELS_DIR/$(basename "$(tier_repo "$1")")"; }
 
 # Pi coding-agent provider registration (--configure-pi). contextWindow is
-# 76800 — far inside GLM-4.7-Flash's 202K native context because the prefill
-# memory guard, not the model, is the binding limit: KV+SDPA grows ~0.433 GB
-# per 1K prompt tokens and the guard's dynamic ceiling (66 GB observed idle,
-# lower under load) rejects single prefills above ~84K tokens (ADR-011;
-# pi_config#889 ladder benchmark). 76800 leaves margin so pi compacts before
-# the guard 400s. Concurrency is the other cap (ADR-009 "The Mark", ADR-010).
+# 122880 — gpt-oss-120b's native 131,072 positions minus the 8,192 maxTokens
+# decode reservation. Unlike the GLM era (ADR-011, guard-bound at 76800), the
+# MODEL's position limit is now the binding constraint: the ~0.070 GB/1K KV
+# slope keeps a full-native-context single stream inside the guard's dynamic
+# ceiling — the #73 ladder accepted 130K-token prompts fresh-idle AND after a
+# 4-hour warm-cache soak (ADR-013). Deep transcripts SHOULD still compact
+# around ~60K tokens: past that the enforcer brushes soft pressure and can
+# transiently pause prefill (benign, self-recovering — ADR-013 consequences).
 PI_AGENT_DIR="${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}"
-PI_CONTEXT_WINDOW=76800
+PI_CONTEXT_WINDOW=122880
 # maxTokens 8192: pi's output shrink ladder caps completions at 8,000
-# (pi_config ADR-0108); a larger value only inflates the prefill guard's
-# decode reservation on a KV-pool-constrained host (ADR-012).
+# (pi_config ADR-0108); stands under ADR-013 — it also sets the decode
+# reservation subtracted from the native window for contextWindow above.
 PI_MAX_TOKENS=8192
 
 DAEMON_LABEL="com.local.iogpu-wired-limit"
@@ -773,8 +778,8 @@ print_pin_instructions() {
 #   absent  oMLX has never registered this model — no PUT should be sent
 #           (retired tiers are never actively aliased/registered by us)
 #   dirty   present and still is_pinned or dflash_ssd_cache — OR still holding
-#           the primary alias (an unpinned 8-bit squatting on 'coding-workhorse'
-#           would collide with the 6-bit's alias PUT; ADR-010) — needs a PUT
+#           the primary alias (an unpinned GLM squatting on 'coding-workhorse'
+#           would collide with the workhorse's alias PUT; ADR-010/013) — needs a PUT
 #   clean   present, unpinned/dflash-off, not on the primary alias — nothing to do
 # Shared by pins_converged (gate) and apply_pins (action) — one source of truth.
 retired_model_state() {
@@ -1228,9 +1233,10 @@ validate_endpoint() {
         return
     fi
 
-    # 2. chat completion. max_tokens >= ~200 everywhere: GLM-4.7-Flash emits a
-    # reasoning preamble before the answer/tool call and 120 tokens truncated
-    # mid-call in testing (ADR-009).
+    # 2. chat completion. Generous max_tokens everywhere: gpt-oss emits a
+    # Harmony reasoning channel before the answer/tool call (default effort
+    # medium), so tight budgets truncate mid-reasoning (ADR-013; the GLM-era
+    # preamble constraint had the same shape).
     local chat_req chat_resp
     chat_req='{"model":"'"$PRIMARY_ALIAS"'","messages":[{"role":"user","content":"Reply with the single word: pong"}],"max_tokens":256}'
     if chat_resp="$(curl -fsS -H "$auth" -H 'Content-Type: application/json' -d "$chat_req" "${base}/chat/completions" 2>/dev/null)"; then
@@ -1240,9 +1246,10 @@ validate_endpoint() {
         record_err "validate-chat" "chat completion request failed"
     fi
 
-    # 3. tool-calling
+    # 3. tool-calling (Harmony format; max_tokens 512 covers the reasoning
+    # channel ahead of the call — the #73 battery ran 58/58 at this budget)
     local tool_req tool_resp
-    tool_req='{"model":"'"$PRIMARY_ALIAS"'","messages":[{"role":"user","content":"What files are in the current directory? Use the tool."}],"tools":[{"type":"function","function":{"name":"list_dir","description":"List files in a directory","parameters":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}}],"tool_choice":"auto","max_tokens":256}'
+    tool_req='{"model":"'"$PRIMARY_ALIAS"'","messages":[{"role":"user","content":"What files are in the current directory? Use the tool."}],"tools":[{"type":"function","function":{"name":"list_dir","description":"List files in a directory","parameters":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}}],"tool_choice":"auto","max_tokens":512}'
     if tool_resp="$(curl -fsS -H "$auth" -H 'Content-Type: application/json' -d "$tool_req" "${base}/chat/completions" 2>/dev/null)"; then
         if echo "$tool_resp" | grep -q 'tool_calls'; then
             ok "validate-tools" "model emitted tool_calls markup"
@@ -1254,18 +1261,21 @@ validate_endpoint() {
         record_err "validate-tools" "tool-calling request failed"
     fi
 
-    # 4. concurrency probe — two parallel completions confirm the batched LLM
-    # engine handles the fan-out this project exists to serve. A single-stream
-    # check cannot detect a server that serializes or fails under concurrency.
+    # 4. admission-queueing probe — two parallel requests against the serial
+    # mark (--max-concurrent-requests 1, ADR-013): the second MUST queue at
+    # admission and then complete, not error. This verifies the serial
+    # invariant degrades gracefully when a client misbehaves (double-fired
+    # step, stray second client) — the failure mode the mark-1 flag exists to
+    # absorb. Both requests completing is the pass condition.
     local pid1 pid2 rc1=0 rc2=0
     curl -fsS -H "$auth" -H 'Content-Type: application/json' -d "$chat_req" "${base}/chat/completions" >/dev/null 2>&1 & pid1=$!
     curl -fsS -H "$auth" -H 'Content-Type: application/json' -d "$chat_req" "${base}/chat/completions" >/dev/null 2>&1 & pid2=$!
     wait "$pid1" || rc1=$?
     wait "$pid2" || rc2=$?
     if [ "$rc1" -eq 0 ] && [ "$rc2" -eq 0 ]; then
-        ok "validate-concurrent" "2 parallel completions succeeded (batched engine handles concurrency)"
+        ok "validate-queueing" "2 parallel requests both completed (second queued at admission per the serial mark)"
     else
-        record_err "validate-concurrent" "parallel completions failed (rc ${rc1}/${rc2}) — check --max-concurrent-requests and the server logs ($LOG_DIR)"
+        record_err "validate-queueing" "queued request failed (rc ${rc1}/${rc2}) — check --max-concurrent-requests and the server logs ($LOG_DIR)"
     fi
 
     # 5. Anthropic-style messages endpoint (spec requires /v1/messages reachability)

--- a/templates/omlx-start-wrapper.sh
+++ b/templates/omlx-start-wrapper.sh
@@ -60,20 +60,21 @@ fi
 # saturation surfaces as server-level backpressure, not Metal wiring failures. It
 # replaced the removed --max-process-memory flag (ADR-002); per oMLX #702 it
 # monitors Metal allocations, not total RSS.
-# --hot-cache-max-size accepts both absolute sizes ('24GB') and percentages
-# ('20%'). We pin an absolute 24GB for a deterministic hot-cache footprint
-# independent of how oMLX resolves a percentage (≈ 27% of the 90 GB guard — up
-# from ADR-006's 18GB: one model, no second cache to fund; ADR-009).
+# --hot-cache-max-size accepts both absolute sizes ('8GB') and percentages
+# ('20%'). We pin an absolute 8GB for a deterministic hot-cache footprint:
+# the gpt-oss workhorse's 61.6 GB of weights leave no room for the GLM-era
+# 24GB tier under the guard's ~73 GB dynamic ceiling; 8GB was the sizing
+# validated by the ADR-013 4-hour serial soak (prefix-cache reuse 0.980).
 # --paged-ssd-cache-max-size caps the SSD tier of the prefix cache; left unset,
-# oMLX defaults it to 100GB — past the setup preflight's 90 GB free-disk budget.
-# 50GB keeps model (~24 GB) + SSD cache inside that budget with ~16 GB slack.
-# --max-concurrent-requests 4 is ADR-012's large-context Mark, amending
-# ADR-010's 8 (which was measured at ~16K contexts). The KV pool is ~83K tokens
-# of TOTAL concurrent context (66 GB dynamic ceiling − ~30 GB weights/baseline
-# at ~0.433 GB/1K tokens — ADR-011); eight admitted 25-45K agentic streams
-# oversubscribe it ~3× (2026-07-26 incident: guard 400s at 40K/53K, decode
-# collapse, cache-evict spiral — pi_config#889). At 4 — matching the pi
-# subagent spawn cap — excess requests queue at admission, consuming no KV.
+# oMLX defaults it to 100GB. 50GB keeps model (~66 GB) + SSD cache inside the
+# setup preflight's 130 GB free-disk budget with headroom.
+# --max-concurrent-requests 1 is ADR-013's serial mark, superseding ADR-012's
+# 4: the host serves a strictly serial workflow (one request in flight, growing
+# transcript), and the workhorse's weights leave no multi-stream KV pool. The
+# flag converts the client-side serial assumption into a server-enforced
+# invariant — a double-fired step or stray second client queues at admission
+# (consuming no KV) instead of competing for the pool. Restoring parallel
+# serving is a MODEL decision (revert to the GLM fallback), not a flag tweak.
 # --host pins the loopback bind explicitly so "local-only" does not depend on an
 # upstream default (one oMLX config class defaults to 0.0.0.0).
 exec "__BREW_PREFIX__/bin/omlx" serve \
@@ -83,6 +84,6 @@ exec "__BREW_PREFIX__/bin/omlx" serve \
     --memory-guard-gb 90 \
     --paged-ssd-cache-dir "__CACHE_DIR__" \
     --paged-ssd-cache-max-size 50GB \
-    --hot-cache-max-size 24GB \
-    --max-concurrent-requests 4 \
+    --hot-cache-max-size 8GB \
+    --max-concurrent-requests 1 \
     --api-key "$api_key"

--- a/templates/omlxctl
+++ b/templates/omlxctl
@@ -4,7 +4,7 @@
 #
 # The server is NOT started at login (the LaunchAgent is RunAtLoad=false). Startup
 # is intentional: this tool starts it on demand and stops it cleanly so the
-# resident model (~24 GB) + KV/prefix cache are released back to the system.
+# resident model (~66 GB) + KV/prefix cache are released back to the system.
 #
 # Usage:
 #   omlxctl start    Start the server (no-op if already running); wait for ready
@@ -46,8 +46,9 @@ STDOUT_LOG="${LOG_DIR}/launchagent.out.log"
 STDERR_LOG="${LOG_DIR}/launchagent.err.log"
 TAIL_LINES="${OMLX_TAIL_LINES:-80}"
 
-# Cold start loads ~24 GB from disk and wires it; ~90s is typical, so poll /health
-# up to READY_TIMEOUT. SIGTERM flushes up to 24 GB of hot cache to SSD on shutdown,
+# Cold start loads ~66 GB from disk and wires it (~10–25s measured on-host, but
+# allow slack), so poll /health up to READY_TIMEOUT. SIGTERM flushes up to 8 GB
+# of hot cache to SSD on shutdown,
 # so allow STOP_TIMEOUT before escalating to SIGKILL. (ADR-005; omlx serve timings.)
 READY_TIMEOUT="${OMLX_READY_TIMEOUT:-120}"
 STOP_TIMEOUT="${OMLX_STOP_TIMEOUT:-30}"
@@ -94,7 +95,7 @@ _wait_ready() {
         return 0
     fi
     local deadline=$(( $(date +%s) + READY_TIMEOUT ))
-    info "Waiting for ${HEALTH_URL} (up to ${READY_TIMEOUT}s; cold start loads ~24 GB)"
+    info "Waiting for ${HEALTH_URL} (up to ${READY_TIMEOUT}s; cold start loads ~66 GB)"
     while :; do
         if _health_ok; then return 0; fi
         if ! _is_running; then

--- a/templates/pi-models-omlx.json
+++ b/templates/pi-models-omlx.json
@@ -8,22 +8,27 @@
 // request time and never stored as a literal — this file contains no secret.
 //
 // compat flags for oMLX's OpenAI-completions endpoint:
-//   supportsDeveloperRole: false    — oMLX/Qwen do not accept the 'developer' role
-//   supportsReasoningEffort: false  — reasoning_effort is not implemented
+//   supportsDeveloperRole: false    — oMLX does not accept the 'developer' role
+//   supportsReasoningEffort: false  — the TOP-LEVEL reasoning_effort param is
+//                                     ignored by oMLX 0.5.7 (verified in
+//                                     psmfd/local-llm#73); effort control is
+//                                     delivered via chat_template_kwargs by the
+//                                     pi payload-tuner (pi_config#1052)
 //   supportsUsageInStreaming: true  — oMLX serves usage in the final stream chunk
 //                                     when stream_options.include_usage is requested
 //                                     (verified live 2026-07-05; psmfd/local-llm#34)
 //
-// Single workhorse model (ADR-009), addressed by its oMLX ALIAS (verified to
-// resolve on the installed version):
-//   coding-workhorse  GLM-4.7-Flash-6bit  pinned, sole resident model (ADR-010)
+// Single workhorse model (ADR-009 structure, ADR-013 model), addressed by its
+// oMLX ALIAS (verified to resolve on the installed version):
+//   coding-workhorse  gpt-oss-120b-4bit  pinned, sole resident model (ADR-013)
 // High-fidelity work routes to the cloud frontier, not this provider.
 //
-// contextWindow is held to 76800 (far inside GLM's 202K native context): the
-// prefill memory guard rejects single prefills above ~84K tokens at its
-// observed idle dynamic ceiling (66 GB; KV+SDPA ~0.433 GB/1K tokens — ADR-011,
-// pi_config#889), and safe concurrency is prefill-activation-bound (ADR-009
-// "The Mark"). 76800 keeps pi compacting before the guard returns 400s.
+// contextWindow 122880 = gpt-oss-120b's native 131,072 positions minus the
+// 8,192 maxTokens decode reservation. The model's position limit — not the
+// prefill guard — is the binding constraint (ADR-013: 130K-token prompts
+// accepted fresh-idle and post-soak; KV ~0.070 GB/1K). pi SHOULD still compact
+// deep transcripts around ~60K tokens: past that the memory enforcer brushes
+// soft pressure and can transiently pause prefill (benign, self-recovering).
 {
   "providers": {
     "omlx": {
@@ -39,8 +44,8 @@
       "models": [
         {
           "id": "__MODEL_ID__",
-          "name": "coding-workhorse — GLM-4.7-Flash (local oMLX)",
-          "reasoning": false,
+          "name": "coding-workhorse — gpt-oss-120b (local oMLX)",
+          "reasoning": true,
           "input": ["text"],
           "contextWindow": __PI_CONTEXT_WINDOW__,
           "maxTokens": __PI_MAX_TOKENS__,


### PR DESCRIPTION
## Summary

Implements **ADR-013**: the host moves from parallel fan-out serving to a **serial workflow architecture**, and the pinned workhorse changes from `GLM-4.7-Flash-6bit` to **`mlx-community/gpt-oss-120b-4bit`**. Evidence chain: #71 (DFlash revisit, closed no-go), #73 (performance probes, quality eval, Phase-0 gates — all passed on the exact target flags this PR ships).

Headline evidence: HumanEval 95.7% vs 83.5% (McNemar p = 0.00018), +27% short-context decode (~106 tok/s), ~3× prefill, 58/58 Harmony tool battery, 130K-token prompts accepted, 4.09 h serial soak clean (prefix reuse 0.980, RSS flat).

## Changes

- **`adrs/013-gptoss-serial-workhorse.md`** (new, accepted) — decision + measured table + serving parameters + rollback; ADR-009/010/011/012 status lines carry the amendment chain (bodies untouched per supersession convention).
- **`setup-omlx-m5.sh`** — workhorse constants → gpt-oss; GLM-6bit joins `RETIRED_MODELS` with alias rename `workhorse-glm` (primary inactive fallback; the alias-transfer pattern from ADR-010); disk preflight 90 → 130 GB; `--validate`: concurrency probe → **admission-queueing** check (serial mark), Harmony tool budget 512.
- **`templates/omlx-start-wrapper.sh`** — `--max-concurrent-requests 4 → 1`, `--hot-cache-max-size 24GB → 8GB` (soak-validated), comments cite ADR-013.
- **`templates/pi-models-omlx.json`** — `contextWindow 122880`, `reasoning: true`, compat comment documents that the top-level `reasoning_effort` param is ignored (delivery via `chat_template_kwargs`, pi_config#1052).
- **`templates/omlxctl`** — size/timing comments (~66 GB model, 8 GB cache flush).
- **Docs** — CLAUDE.md, README, `docs/workhorse-probes.md` (ADR-013 note marking probes 1–2 as GLM-fallback-era, gpt-oss gauntlet summary), `docs/router-wiring.md` (serial mark; guard-400 semantics: backoff-retry → **compact-and-resubmit**; Harmony max_tokens note).

## Doc impact (classification from the approved plan)

All in-scope surfaces landed here. Out-of-scope-but-tracked: pi payload-tuner change → psmfd/pi_config#1052. Not-a-thing: `probes/thinking-ab/` (GLM-era history, retained), upstream-watch/brew pin (model-independent).

## Merge order

**Merge #72 first** (probe-5 baseline). This branch already contains #72's commit content, so its diff shrinks to the ADR-013 changes once #72 lands; identical hunks merge cleanly.

## Validation

- `shellcheck --severity=warning` clean on `setup-omlx-m5.sh`, wrapper, `omlxctl`; `bash -n` clean.
- `markdownlint-cli2` clean on all changed files (repo-wide findings are gitignored `.session-notes/` only).
- Plists untouched.
- Serving flags, context boundary, tool budget, and cache sizing are exactly the values validated live in #73's Phase-0 gauntlet.

## Cutover runbook (after merge)

1. `git pull` on dev → `./setup-omlx-m5.sh` (idempotent: re-renders wrapper, applies pin/alias transfer via admin API — gpt-oss is already on disk from the probe)
2. `omlxctl start` → `./setup-omlx-m5.sh --validate` (six checks incl. the new queueing probe)
3. `./setup-omlx-m5.sh --configure-pi` → merge the snippet (contextWindow/name changes)
4. pi_config#1052 lands the client-side `reasoning_effort` change
5. Rollback at any point: repoint pin to `workhorse-glm`, restore GLM-era flags (ADR-010/011/012 values), restart.

Closes #73. Refs #71, psmfd/pi_config#1052.
