### PR TITLE
fix(setup): converge is_default onto the pinned workhorse (#77)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,10 @@ omlxctl restart  # atomic restart + wait         |  omlxctl status  # launchd + 
 Exit codes: `0` pass, `1` errors, `2` precondition failure. The Metal
 wired-limit step needs `sudo`. The workhorse alias + pin is applied via the
 **oMLX admin API** (`apply_pins` briefly starts the server, PUTs the model's
-settings — and **unpins any retired tiers** it finds registered, renaming the
-GLM-6bit to alias `workhorse-glm` (and the 8-bit to `workhorse-8b`) so the
+settings, including `is_default` so the **pinned workhorse owns the default
+model** (#77 — oMLX otherwise derives it from registry order, which lands on a
+retired tier) — and **unpins any retired tiers** it finds registered, renaming
+the GLM-6bit to alias `workhorse-glm` (and the 8-bit to `workhorse-8b`) so the
 primary alias transfers to gpt-oss — then stops it; `model_settings.json` is
 oMLX-owned, so the script never writes it directly); it degrades to printed
 manual admin-panel steps if the API can't be reached (ADR-009/013).
@@ -305,7 +307,9 @@ After the server is up, validate against `http://localhost:8000/v1` (the script'
    too and is NOT diagnostic). Setup's `converge_settings` step repairs
    persisted `settings.json` drift against the wrapper flags (server stopped);
    `apply_pins` additionally unpins any STRAY pin outside the tier lineup
-   (#43, sole-resident invariant), warning loudly by name.
+   (#43, sole-resident invariant) and clears any STRAY `is_default` (#77 — a
+   default can sit on an *unpinned* model, so it needs its own pass), warning
+   loudly by name.
 
 Anthropic-style clients use `/v1/messages`. The downstream consumer is an
 `IInferenceBackend` / `FallbackInferenceRouter`: fast/balanced roles →

--- a/setup-omlx-m5.sh
+++ b/setup-omlx-m5.sh
@@ -779,8 +779,11 @@ print_pin_instructions() {
 #           (retired tiers are never actively aliased/registered by us)
 #   dirty   present and still is_pinned or dflash_ssd_cache — OR still holding
 #           the primary alias (an unpinned GLM squatting on 'coding-workhorse'
-#           would collide with the workhorse's alias PUT; ADR-010/013) — needs a PUT
-#   clean   present, unpinned/dflash-off, not on the primary alias — nothing to do
+#           would collide with the workhorse's alias PUT; ADR-010/013) — OR
+#           still holding is_default (#77: a retired tier must not be the
+#           model the server resolves for a default-model consumer) — needs a PUT
+#   clean   present, unpinned/dflash-off, not on the primary alias, not the
+#           default — nothing to do
 # Shared by pins_converged (gate) and apply_pins (action) — one source of truth.
 retired_model_state() {
     local repo="$1"
@@ -795,6 +798,7 @@ m = models.get(sys.argv[2])
 if not m:
     print("absent")
 elif (bool(m.get("is_pinned")) or bool(m.get("dflash_ssd_cache"))
+      or bool(m.get("is_default"))
       or m.get("model_alias") == sys.argv[3]):
     print("dirty")
 else:
@@ -827,9 +831,14 @@ for t in sys.argv[2:]:
     m = models.get(mid)
     if not m or m.get("model_alias") != alias or bool(m.get("is_pinned")) != (pin == "true"):
         sys.exit(1)
-# Sole-resident invariant: any pin outside the tier lineup is a stray (#43).
+    # The pinned workhorse must also OWN the default (#77): oMLX otherwise
+    # derives it from registry order, which lands on a retired tier.
+    if pin == "true" and not bool(m.get("is_default")):
+        sys.exit(1)
+# Sole-resident invariant: any pin — or default (#77) — outside the tier
+# lineup is a stray (#43).
 for mid, m in models.items():
-    if bool(m.get("is_pinned")) and mid not in pinned_tiers:
+    if mid not in pinned_tiers and (bool(m.get("is_pinned")) or bool(m.get("is_default"))):
         sys.exit(1)
 sys.exit(0)
 PYEOF
@@ -864,6 +873,31 @@ for t in sys.argv[2:]:
         pinned_tiers.add(os.path.basename(repo))
 for mid, m in models.items():
     if bool(m.get("is_pinned")) and mid not in pinned_tiers:
+        print(f"{mid}|{m.get('model_alias') or ''}")
+PYEOF
+}
+
+# stray_defaults — prints one "model_id|alias" line per model holding
+# is_default in model_settings.json that is not the pinned TIER_MODELS entry.
+# Mirrors stray_pins (#43) for the default flag (#77). A default can sit on an
+# UNPINNED model — the GLM-6bit case that motivated this — so stray_pins does
+# not catch it and a separate pass is required. Retired tiers handled by the
+# unpin pass may also appear here; the extra PUT is idempotent.
+stray_defaults() {
+    [ -f "$OMLX_HOME/model_settings.json" ] || return 0
+    python3 - "$OMLX_HOME/model_settings.json" "${TIER_MODELS[@]}" <<'PYEOF' 2>/dev/null || true
+import json, os, sys
+try:
+    models = json.load(open(sys.argv[1])).get("models", {})
+except Exception:
+    sys.exit(0)
+pinned_tiers = set()
+for t in sys.argv[2:]:
+    repo, alias, pin = t.split("|")
+    if pin == "true":
+        pinned_tiers.add(os.path.basename(repo))
+for mid, m in models.items():
+    if bool(m.get("is_default")) and mid not in pinned_tiers:
         print(f"{mid}|{m.get('model_alias') or ''}")
 PYEOF
 }
@@ -991,7 +1025,7 @@ apply_pins() {
             absent) skip "unpin-${rmid}" "not in model_settings.json — never registered, nothing to unpin" ;;
             clean)  skip "unpin-${rmid}" "already unpinned (DFlash off, primary alias clear)" ;;
             dirty)
-                body="{\"model_alias\":\"${ralias}\",\"is_pinned\":false,\"ttl_seconds\":900,\"dflash_ssd_cache\":false}"
+                body="{\"model_alias\":\"${ralias}\",\"is_pinned\":false,\"is_default\":false,\"ttl_seconds\":900,\"dflash_ssd_cache\":false}"
                 if curl -fsS --max-time 20 -X PUT -b "$cookie_jar" -H "$auth" -H 'Content-Type: application/json' \
                     -d "$body" "${base}${admin}/models/${rmid}/settings" >/dev/null 2>&1; then
                     ok "unpin-${rmid}" "retired model unpinned as '${ralias}' (stays on disk; memory freed on next start)"
@@ -1014,9 +1048,9 @@ apply_pins() {
         # (--paged-ssd-cache-dir) stays ON — its live upstream risk is oMLX #702
         # (the memory guard tracks Metal allocations, not cache RSS).
         if [ "$pin" = "true" ]; then
-            body="{\"model_alias\":\"${alias}\",\"is_pinned\":true,\"dflash_ssd_cache\":false}"
+            body="{\"model_alias\":\"${alias}\",\"is_pinned\":true,\"is_default\":true,\"dflash_ssd_cache\":false}"
         else
-            body="{\"model_alias\":\"${alias}\",\"is_pinned\":false,\"ttl_seconds\":900,\"dflash_ssd_cache\":false}"
+            body="{\"model_alias\":\"${alias}\",\"is_pinned\":false,\"is_default\":false,\"ttl_seconds\":900,\"dflash_ssd_cache\":false}"
         fi
         if curl -fsS --max-time 20 -X PUT -b "$cookie_jar" -H "$auth" -H 'Content-Type: application/json' \
             -d "$body" "${base}${admin}/models/${mid}/settings" >/dev/null 2>&1; then
@@ -1050,6 +1084,26 @@ apply_pins() {
             record_warn "stray-pin" "stray pin on ${smid} could not be unpinned via admin PUT — unpin it manually at ${base}/admin (sole-resident invariant, ADR-009)"
         fi
     done <<< "$(stray_pins)"
+
+    # Stray defaults (#77): the default can sit on an UNPINNED model, so the
+    # stray-pin pass above does not clear it. Runs AFTER the workhorse PUT has
+    # claimed is_default, so this only ever clears a leftover holder.
+    local dmid dalias
+    while IFS='|' read -r dmid dalias; do
+        [ -n "$dmid" ] || continue
+        # dalias is operator/admin-panel state — same charset guard as the
+        # stray-pin pass; the PUT merges, so omitting it leaves it untouched.
+        case "$dalias" in
+            (*[!A-Za-z0-9._-]*|"") body="{\"is_default\":false}" ;;
+            (*) body="{\"model_alias\":\"${dalias}\",\"is_default\":false}" ;;
+        esac
+        if curl -fsS --max-time 20 -X PUT -b "$cookie_jar" -H "$auth" -H 'Content-Type: application/json' \
+            -d "$body" "${base}${admin}/models/${dmid}/settings" >/dev/null 2>&1; then
+            record_warn "stray-default" "cleared STRAY is_default on ${dmid} (alias '${dalias:-none}') — the default belongs on the pinned workhorse (#77)"
+        else
+            record_warn "stray-default" "stray is_default on ${dmid} could not be cleared via admin PUT — clear it manually at ${base}/admin (#77)"
+        fi
+    done <<< "$(stray_defaults)"
 
     if ! $workhorse_present; then
         record_warn "pin" "workhorse model not on disk — download it with --download-model, then re-run to pin it (any retired-tier memory was still freed this run)"


### PR DESCRIPTION
Closes #77.

## Problem

`apply_pins` converged `model_alias`, `is_pinned`, `ttl_seconds` and
`dflash_ssd_cache` — but never `is_default`. The sole-resident invariant
(ADR-009/013) was therefore enforced for the *pin* but not for the *default
model*.

On the live host (oMLX 0.5.7):

```
GET /health → {"default_model":"GLM-4.7-Flash-6bit", ...}
```

…while `settings.is_default` is `false`/`null` for **every** registered model.
Nothing explicitly claims the default, so oMLX derives it from registry order,
which lands on `GLM-4.7-Flash-6bit` (`G` < `Q` < `g` < `m`) — a retired tier.

## Severity: latent, not an active hazard

Stated precisely, because initial triage over-stated it:

- `ChatCompletionRequest` has `required: ['model', 'messages']` — a request
  cannot omit `model`.
- `model.model_fallback` is `false`, so an unknown model name errors rather
  than falling back to the default.

So no `/v1/chat/completions` path reaches the default implicitly. It still
warrants fixing: the derived value shifts silently as `~/models` changes,
`/health` actively misleads during triage, and other surfaces do consume a
default (admin panel selection, the `integrations.*_model` /
`claude_code.*_model` slots in global-settings). Were a co-resident load ever
triggered, 61.57 + 23.80 = 85.37 GiB against a hard ceiling of 85.5 GiB, with
gpt-oss pinned and therefore not evictable.

## Changes

| | |
|---|---|
| `retired_model_state` | a retired tier still holding `is_default` is now `dirty`, so the unpin pass fires for it |
| `pins_converged` | the pinned tier must own the default, and no other model may hold it |
| `apply_pins` | `is_default:true` on the workhorse PUT; `is_default:false` on the retired-tier unpin PUT |
| `stray_defaults` | **new** pass mirroring `stray_pins` |

`stray_defaults` is necessary rather than cosmetic: a default can sit on an
*unpinned* model — precisely the GLM-6bit case here — so `stray_pins`
structurally cannot catch it.

**The `pins_converged` change is what makes the fix reachable.** Before it, a
host in the current state satisfied the gate, so `apply_pins` short-circuited
the entire start/pin/stop cycle and the repair would never have run on an
already-provisioned host.

Pass ordering inside `apply_pins` is retired-unpin → workhorse-pin →
stray-pins → stray-defaults, so the old holder is cleared before the workhorse
claims the flag.

## Mechanism

`PUT /admin/api/models/{model_id}/settings` already accepts `is_default`
(`ModelSettingsRequest.is_default: boolean | null`), verified against the
running 0.5.7 OpenAPI. No new API surface, and `model_settings.json` stays
oMLX-owned — the script still never writes it directly.

## Verification

Extracted the four helpers against synthetic `model_settings.json` fixtures:

| fixture | `retired_model_state` | `pins_converged` | `stray_defaults` |
|---|---|---|---|
| live host (GLM holds default) | `dirty` | no | `GLM-4.7-Flash-6bit` |
| repaired (gpt-oss holds it) | `clean` | **YES** | — |
| no default anywhere *(pre-patch false-converged)* | `clean` | **no** | — |
| off-lineup stray default | `absent` | no | `Qwen3-0.6B-4bit` |
| stray pin *(#43 regression check)* | `absent` | no | — (`stray_pins` fires) |
| missing `model_settings.json` | `absent` | no | — |

Row 2 confirms idempotency (a converged host still skips the server churn); row
3 is the case the patch exists to fix.

CI gate locally: `shellcheck --severity=warning` clean, `markdownlint-cli2`
0 issues across 30 files, both plists well-formed.

## Note

This patches the provisioning path only. The live host keeps reporting
`default_model: GLM-4.7-Flash-6bit` until `./setup-omlx-m5.sh` is re-run on the
Mac; no live-server mutation was applied out of band.
